### PR TITLE
Navbar declutter + Connect SDK quickstart slim-down for 0.8

### DIFF
--- a/docs/connect/quickstart.md
+++ b/docs/connect/quickstart.md
@@ -5,15 +5,45 @@ sidebar_label: Quickstart
 
 # Connect SDK Quickstart
 
-The fastest way to see the SDK working is to copy one of the snippets
-below into a page, run it in `isDemo: true` mode, and watch the wizard
-render. Swap in your real `apiToken` and `tenant` / `employer`
-identifiers when you're ready to leave demo mode.
+This page shows the smallest possible page that mounts the SDK. For
+the full step-by-step (token issuance, employer + user configuration,
+mobile / WebView patterns, MFA, fix-credentials), see
+[**SDK Reference → Quickstart**](/sdk/quickstart) — it's the canonical
+source maintained alongside the SDK code itself.
 
-For every configuration option and lifecycle callback, see the
-[SDK Reference](/sdk/).
+## Demo mode (CDN)
 
-## npm (recommended)
+The minimum viable SDK page. Drops the SDK into the
+`#sdk-hook` element and runs in `isDemo: true`, which mounts the
+wizard but doesn't talk to TPA Stream.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://app.tpastream.com/static/js/sdk.js"></script>
+    <script>
+      window.StreamConnect({
+        el: "#sdk-hook",
+        isDemo: true,
+      });
+    </script>
+  </head>
+  <body>
+    <div id="sdk-hook"></div>
+  </body>
+</html>
+```
+
+To leave demo mode, swap `isDemo: false` and add an `sdkToken` your
+backend has issued (the SDK Quickstart walks through the
+token-issuance flow). The 0.8 SDK derives tenant / employer / user
+context from the token; the older
+`tenant: {…}, employer: {…}, user: {…}` init shape from 0.7.x still
+works as a backwards-compat path but isn't the recommended pattern
+for new integrations.
+
+## npm
 
 ```bash
 npm install stream-connect-sdk
@@ -23,103 +53,24 @@ npm install stream-connect-sdk
 import StreamConnect from "stream-connect-sdk";
 
 const sdk = StreamConnect({
-  el: "#react-hook",
+  el: "#sdk-hook",
   isDemo: true,
 });
 ```
 
-## Hosted CDN
+## Pinning a CDN version
 
-```html
-<script src="https://app.tpastream.com/static/js/sdk.js"></script>
-<script>
-  window.StreamConnect({
-    el: "#react-hook",
-    tenant: {
-      systemKey: "test",
-      vendor: "internal",
-    },
-    employer: {
-      systemKey: "some-system-key",
-      vendor: "internal",
-      name: "some-name",
-    },
-    user: {
-      firstName: "Joe",
-      lastName: "Sajor",
-      email: "some-email@place.com",
-      memberSystemKey: "some-system-key",
-      phoneNumber: "333333333",
-      dateOfBirth: "11-11-1121",
-    },
-    apiToken: "Some Provided Key", // TPA Stream provides this
-    isDemo: false,
-    realTimeVerification: true,
-    renderChoosePayer: true,
-    doneGetSDK: ({ user, payers, tenant, employer }) => {},
-    doneChoosePayer: ({ choosePayer, streamPayers }) => {},
-    doneTermsOfService: () => {},
-    doneCreatedForm: () => {},
-    donePostCredentials: ({ params }) => {},
-    doneRealTime: () => {},
-    donePopUp: () => {},
-    doneEasyEnroll: ({ employer, payer, tenant, policyHolder, user }) => {},
-    handleFormErrors: (error, { response, request, config }) => {},
-    userSchema: {},
-  });
-</script>
-```
+The CDN is versioned. The script tag's `src` selects the version:
 
-### Pinning a CDN version
-
-As of SDK 0.4.7, the CDN provider is versioned. The script tag's `src`
-selects the version:
-
-- `https://app.tpastream.com/static/js/sdk.js` — latest
+- `https://app.tpastream.com/static/js/sdk.js` — always the latest
 - `https://app.tpastream.com/static/js/sdk-v-<VersionNumber>.js` — a
-  specific version, e.g. `sdk-v-0.4.7.js`
+  specific version (e.g. `sdk-v-0.8.0.js`). Pinned versions remain
+  available indefinitely.
 
-## Android (WebView)
+## Mobile (Android, iOS, React Native)
 
-Put an HTML file in your `assets/` folder that loads the SDK, then
-load it in a WebView:
-
-```java
-public class ViewWeb extends Activity {
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.content);
-        WebView webview = (WebView) findViewById(R.id.webView);
-        webview.loadUrl("file:///android_asset/stream-connect.html");
-    }
-}
-```
-
-## iOS (WKWebView)
-
-Put an HTML file (here `index.html` in a `stream-connect` directory)
-in your bundle, then load it in a WKWebView:
-
-```objective-c
-import UIKit
-import WebKit
-
-class ViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
-
-    @IBOutlet weak var webView: WKWebView!
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        webView.uiDelegate = self
-        webView.navigationDelegate = self
-        let url = Bundle.main.url(
-            forResource: "index",
-            withExtension: "html",
-            subdirectory: "stream-connect"
-        )!
-        webView.loadFileURL(url, allowingReadAccessTo: url)
-        let request = URLRequest(url: url)
-        webView.load(request)
-    }
-}
-```
+The SDK is web-first. The recommended mobile integration is to embed
+an HTML page loading the SDK in a WebView and ferry callbacks to the
+native host via `postMessage` / message handlers. See
+[SDK Reference → Mobile](/sdk/quickstart#mobile-android-ios-react-native)
+for working WebView snippets in React Native, Android, and iOS.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -75,16 +75,6 @@ const config: Config = {
           position: "left",
         },
         { to: "/sdk/", label: "SDK Reference", position: "left" },
-        {
-          href: "https://app.tpastream.com/rapidoc",
-          label: "RapiDoc",
-          position: "right",
-        },
-        {
-          href: "https://github.com/TPAStream/stream-connect-js-sdk",
-          label: "GitHub",
-          position: "right",
-        },
       ],
     },
     footer: {
@@ -110,13 +100,26 @@ const config: Config = {
           ],
         },
         {
-          title: "More",
+          title: "Source",
           items: [
-            { label: "Sign in", href: "https://app.tpastream.com/login" },
+            {
+              label: "Connect SDK on GitHub",
+              href: "https://github.com/TPAStream/stream-connect-js-sdk",
+            },
             {
               label: "Connect SDK on npm",
               href: "https://www.npmjs.com/package/stream-connect-sdk",
             },
+            {
+              label: "These docs on GitHub",
+              href: "https://github.com/LakeEriePartners/developer-docs",
+            },
+          ],
+        },
+        {
+          title: "More",
+          items: [
+            { label: "Sign in", href: "https://app.tpastream.com/login" },
             {
               label: "Privacy Policy",
               href: "https://app.tpastream.com/privacy",

--- a/scripts/clone-sdk-docs.sh
+++ b/scripts/clone-sdk-docs.sh
@@ -89,6 +89,44 @@ mkdir -p "$SDK_DEST"
 # Copy everything from the SDK docs/ tree (markdown + screenshot subdirs).
 cp -R "$SRC/." "$SDK_DEST/"
 
+# Rewrite markdown links of the form `../something-outside-docs/...`
+# to absolute GitHub blob URLs at the cloned ref. The SDK docs link
+# to sibling source files (../assets/sdk/types.ts) and to the
+# sibling sdk-hook package (../sdk-hook/docs/README.md) — those work
+# on github.com but resolve to /assets/... / /sdk-hook/... inside
+# our build, which 404s. Intra-docs links (./foo.md,
+# ./screenshots/x.png) are left alone.
+SDK_REPO_PATH="$(echo "$SDK_REPO" | sed -E 's|^https?://github.com/||; s|\.git$||')"
+GH_BLOB_BASE="https://github.com/${SDK_REPO_PATH}/blob/${REF}"
+python3 - "$SDK_DEST" "$GH_BLOB_BASE" <<'PYEOF'
+import os, re, sys
+
+dest, gh_base = sys.argv[1], sys.argv[2]
+# Match Markdown links: [text](../path/to/thing[#anchor]).
+# Skip ./… (intra-docs), absolute URLs, anchors-only.
+link_re = re.compile(r'(\[[^\]]*\]\()(\.\./[^)\s#]+)((?:#[^)\s]+)?\))')
+
+rewrites = 0
+for root, _, files in os.walk(dest):
+    for name in files:
+        if not (name.endswith(".md") or name.endswith(".mdx")):
+            continue
+        path = os.path.join(root, name)
+        with open(path, encoding="utf-8") as fh:
+            src = fh.read()
+        def repl(m):
+            global rewrites
+            target = m.group(2)[3:]  # strip the leading ../
+            rewrites += 1
+            return f"{m.group(1)}{gh_base}/{target}{m.group(3)}"
+        new = link_re.sub(repl, src)
+        if new != src:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(new)
+
+print(f"rewrote {rewrites} ../ link(s) to {gh_base}")
+PYEOF
+
 # README.md (SDK convention) → index.md (Docusaurus convention).
 if [ -f "$SDK_DEST/README.md" ]; then
   mv "$SDK_DEST/README.md" "$SDK_DEST/index.md"

--- a/src/clientModules/legacy-anchor-redirects.ts
+++ b/src/clientModules/legacy-anchor-redirects.ts
@@ -44,11 +44,13 @@ const PAGE_TO_ANCHOR_MAP: AnchorMap = {
     "detailed-client-usage-docs": "/sdk/client-usage",
     "other-useful-documentation-links": "/sdk/",
     "sdk-client-usage-docs": "/sdk/client-usage",
-    "npm-example-recommended": "/connect/quickstart#npm-recommended",
-    "cdn-example": "/connect/quickstart#hosted-cdn",
+    "npm-example-recommended": "/connect/quickstart#npm",
+    "cdn-example": "/connect/quickstart#demo-mode-cdn",
     "pinning-a-cdn-version": "/connect/quickstart#pinning-a-cdn-version",
-    "android-example": "/connect/quickstart#android-webview",
-    "ios-example": "/connect/quickstart#ios-wkwebview",
+    "android-example":
+      "/connect/quickstart#mobile-android-ios-react-native",
+    "ios-example":
+      "/connect/quickstart#mobile-android-ios-react-native",
     "change-log": "/sdk/",
     // Old per-version changelog anchors all fold to the SDK Reference now.
     "v0-4-8-latest": "/sdk/",


### PR DESCRIPTION
## Summary

Two pieces of feedback addressed:

1. **Navbar top-right was confusing.** The "GitHub" link pointed at the Connect SDK repo, but the placement implied "the GitHub for THIS site." The "RapiDoc" link pointed at app.tpastream.com/rapidoc, which is redundant with our own `/api-reference/` (same OpenAPI spec, same try-it-out). Both dropped from the navbar. Source repos are now in a dedicated **Source** footer column with clear labels: "Connect SDK on GitHub", "Connect SDK on npm", "These docs on GitHub".

2. **`/connect/quickstart` was 0.7-shape.** The page mirrored the old SDK README — kitchen-sink init with `tenant` + `employer` + `user` objects + every callback. SDK 0.8 derives that context from the `sdkToken`; the old shape still works as back-compat but isn't what new integrations should follow. Trimmed the page to a minimal CDN demo + npm install + CDN version pinning (now references `sdk-v-0.8.0.js`). Mobile section is a one-line pointer to `/sdk/quickstart#mobile-…` which already has working React Native, Android, and iOS WebView snippets at 0.8 polish level.

## Knock-on

- **`scripts/clone-sdk-docs.sh` rewrites `../`-prefixed links.** The 0.8 SDK docs link out to sibling source files (`../assets/sdk/types.ts`) and the deprecated sdk-hook package (`../sdk-hook/docs/README.md`). Fine on github.com; broken when we ingest just `docs/`. The script now rewrites those to absolute `https://github.com/<repo>/blob/<ref>/...` URLs at clone time. Verified: 10 such links in the current 0.8 branch are rewritten cleanly. Intra-docs links (`./other-doc.md`, `./screenshots/foo.png`) are untouched.
- **Sphinx-anchor redirect map updated** for the trimmed quickstart's renamed headings (`#npm-example-recommended` → `#npm`, etc.).

## Verified

- Built locally with `SDK_REF=0.8.0-react19-tailwind` (the unmerged 0.8 branch — content will resolve from SDK master automatically once that merges, per the script's default).
- `docker build` clean.
- Navbar contains exactly the 5 internal section links — no RapiDoc, no global GitHub.
- Footer renders 4 columns (Docs / Reference / Source / More) with the SDK + docs GitHub links categorized.
- `/sdk/sdk-flow` renders the 0.8 content (Set-Up / Choose-Payer / Enter Credentials sections all visible).
- `/connect/quickstart` renders the new trimmed content with the `sdkToken` example.
- Zero broken links in the build (down from 8 before the link-rewrite step).

## Test plan

- [ ] Preview verified on http://localhost:8085
- [x] Build clean
- [ ] Reviewer spot-check navbar + footer in browser
- [ ] After SDK 0.8 merges to master, confirm the default build (no `SDK_REF` override) picks up the same content