### PR TITLE
docs: navbar dedupe + API intro description + hide vendor branding from sidebar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -59,7 +59,9 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: "TPA Stream",
+      // No `title` — the logo alone is the wordmark. Setting both
+      // rendered "<logo> TPA Stream" side-by-side which read as a
+      // duplicate.
       logo: {
         alt: "TPA Stream",
         src: "img/logo.png",

--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -248,7 +248,7 @@ if not spec["info"].get("description", "").strip():
         "and rebuilt on every docs deploy, so what you see here "
         "matches what the API serves right now.\n\n"
         "Each endpoint page includes a try-it-out console; you'll "
-        "need an SSH-JWT bearer or an API token to authenticate "
+        "need an `SSH-JWT` token or an API token to authenticate "
         "(see [Authentication](/api/authentication))."
     )
 

--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -101,6 +101,20 @@ def tag_for(path):
         return (label, f"{label} endpoints.")
     return ("Other", "Endpoints that don't fit another category.")
 
+# Rename specific upstream tag names that read badly in the public
+# sidebar — typically tags that bake in the name of a vendor we
+# happen to integrate with (Mailgun, etc.). Once the underlying
+# Blueprint is renamed in stream/, the entry here is harmless until
+# we get around to dropping it. Map: upstream-tag → renamed-tag.
+TAG_RENAMES = {
+    # /api/v2/mailgun-webhook serves an inbound-webhook handler that
+    # currently happens to consume Mailgun's payload shape, but
+    # there's nothing fundamentally Mailgun-specific about it from a
+    # caller perspective. Group it under the generic "Webhooks" tag
+    # alongside the other webhook plumbing.
+    "Mailgun Webhook Event": "Webhooks",
+}
+
 # The upstream spec's individual operations DO carry per-operation
 # tags (flask-smorest derives them from the Blueprint name), but the
 # top-level `tags` array is empty so docusaurus-plugin-openapi-docs
@@ -195,11 +209,12 @@ for path, ops in spec.get("paths", {}).items():
     for method, op in ops.items():
         if method.startswith("x-") or method == "parameters": continue
         if not isinstance(op, dict): continue
-        existing = [t for t in (op.get("tags") or []) if t]
+        existing = [TAG_RENAMES.get(t, t) for t in (op.get("tags") or []) if t]
         if not existing:
             op["tags"] = [derived_name]
             tag_usage.add(derived_name)
         else:
+            op["tags"] = existing
             for t in existing: tag_usage.add(t)
 
 # Preserve any pre-existing top-level tag descriptions.
@@ -212,6 +227,30 @@ spec["tags"] = [
     {"name": name, "description": DESCRIPTIONS.get(name, f"{name} endpoints.")}
     for name in sorted(tag_usage)
 ]
+
+# Synthesize info.description if the upstream spec doesn't ship one.
+# docusaurus-plugin-openapi-docs renders this on the API Reference
+# landing page (/api-reference/tpa-stream-api) — without it, the
+# "Introduction" section comes through empty. Fallback kicks in
+# until the canonical fix lands in stream's flask-smorest config.
+spec.setdefault("info", {})
+if not spec["info"].get("description", "").strip():
+    spec["info"]["description"] = (
+        "TPA Stream's REST API exposes the platform's core data model "
+        "— payers, employers, policy holders, claims, invoices, and "
+        "subscriptions — plus the webhook and SDK plumbing that drives "
+        "the [Connect SDK](/connect/overview).\n\n"
+        "For cross-cutting concerns (authentication, pagination, IP "
+        "allowlists, key generation, date-range serialization) see "
+        "the [REST API guide](/api/overview). The endpoint pages "
+        "below are auto-generated from the canonical OpenAPI spec at "
+        "[`https://app.tpastream.com/openapi.json`](https://app.tpastream.com/openapi.json) "
+        "and rebuilt on every docs deploy, so what you see here "
+        "matches what the API serves right now.\n\n"
+        "Each endpoint page includes a try-it-out console; you'll "
+        "need an SSH-JWT bearer or an API token to authenticate "
+        "(see [Authentication](/api/authentication))."
+    )
 
 with open(dst, "w") as fh:
     json.dump(spec, fh, sort_keys=True, indent=2)


### PR DESCRIPTION
## Summary

Three independent review fixes against the just-merged docs site at https://developers.tpastream.com.

### 1. Navbar dedupe

Currently renders "**\<logo\> TPA Stream**" top-left — the logo *plus* a `navbar.title` that's the same wordmark twice. Dropped `navbar.title`; logo only.

### 2. API Reference Introduction was empty

[/api-reference/tpa-stream-api](https://developers.tpastream.com/api-reference/tpa-stream-api) rendered an empty Introduction. The OpenAPI plugin uses `spec.info.description` for that section; flask-smorest doesn't set one upstream.

Fix: synthesize a description in `sync-openapi.sh` if `info.description` is empty — covers what the API exposes, where the cross-cutting concerns live, how to authenticate. Companion stream PR adds the canonical fix in `flask-smorest` config; this fallback becomes a no-op once that ships.

### 3. "Mailgun Webhook Event" in the sidebar

[/api-reference/mailgun-webhook-event](https://developers.tpastream.com/api-reference/mailgun-webhook-event) was bucketing the inbound-email-webhook endpoint under a vendor-named tag. Bakes our current vendor choice into the public-facing sidebar even though we may swap to SES inside the next year.

Fix: `TAG_RENAMES` map in `sync-openapi.sh` rewrites the upstream "Mailgun Webhook Event" → "Webhooks" at sync time. The endpoint URL `/api/v2/mailgun-webhook` is unchanged (back-compat); only the classification shifts. Companion stream PR will add a vendor-neutral path alias and rename the Blueprint upstream, at which point the `TAG_RENAMES` entry here can be dropped.

## Verified locally

- Tag count went from 19 → 18; "Mailgun Webhook Event" gone, "Webhooks" picked up the operation
- `/api-reference/tpa-stream-api` Introduction now renders the synthesized description
- Navbar HTML contains no `navbar__title` element — only the logo

## Test plan

- [x] Preview verified on http://localhost:8085
- [x] Build clean (zero broken links, 91 endpoint pages)
- [ ] Reviewer spot-check that the navbar reads "(logo only)" not "(logo) TPA Stream"
- [ ] Reviewer scroll-check that the API Reference landing page Introduction has prose
- [ ] Reviewer confirm no "Mailgun" string in the API sidebar