### PR TITLE
openapi: inject servers field so code samples use app.tpastream.com

### DIFF
--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -228,6 +228,18 @@ spec["tags"] = [
     for name in sorted(tag_usage)
 ]
 
+# Inject `servers` if the upstream spec doesn't define it. Without
+# this, docusaurus-plugin-openapi-docs' code samples default to the
+# docs site's own hostname (developers.tpastream.com), which yields
+# nonsense like `curl https://developers.tpastream.com/api/...` —
+# the API lives at app.tpastream.com. Canonical fix is in stream's
+# flask-smorest config (companion stream PR); this fallback kicks
+# in only when info.servers is unset.
+if not spec.get("servers"):
+    spec["servers"] = [
+        {"url": "https://app.tpastream.com", "description": "Production"}
+    ]
+
 # Synthesize info.description if the upstream spec doesn't ship one.
 # docusaurus-plugin-openapi-docs renders this on the API Reference
 # landing page (/api-reference/tpa-stream-api) — without it, the


### PR DESCRIPTION
User-reported bug: the C# (and curl, etc.) code samples in the API Reference show URLs like `https://developers.tpastream.com/api/v2/vendor-tenant/:vendor_tenant_label/employer` because the OpenAPI plugin defaults to the current page hostname when the spec has no `servers` field. The API actually lives at `https://app.tpastream.com`.

The upstream spec doesn't define `servers` at all (returns `null`):
```bash
curl -sS https://app.tpastream.com/openapi.json | jq '.servers'
# null
```

So docusaurus-plugin-openapi-docs falls back to the page origin.

Synthesize the `servers` list in `sync-openapi.sh` as a stopgap until the canonical fix lands in stream's flask-smorest config ([stream#14377](https://github.com/LakeEriePartners/stream/pull/14377) — adds `FlaskSmorestConfig.API_SERVERS`). Once stream's PR ships, the synth fallback here is a no-op.