### PR TITLE
docs(connect): refresh Replay Webhook screenshot

### DIFF
--- a/docs/connect/webhooks-claim.md
+++ b/docs/connect/webhooks-claim.md
@@ -25,7 +25,7 @@ that URL.
 
 ## Replaying a claim post
 
-<img src="/img/replay-claim-webhook.png" alt="Replay claim webhook" width="400" />
+<img src="https://tpastream-public.s3.amazonaws.com/webapp-docs/claims/replay-claim-webhook.png" alt="Replay claim webhook" width="700" />
 
 To manually replay a claim post, find the claim on the claims page
 and click **Replay webhook**. If the button isn't shown, verify that


### PR DESCRIPTION
## Summary

Swap the stale 0.7-era `/img/replay-claim-webhook.png` for a fresh
shot of the current UI on
`/d/claims-harvesting/claims` → row hamburger → **Replay Webhook**.

New URL:
https://tpastream-public.s3.amazonaws.com/webapp-docs/claims/replay-claim-webhook.png

## Why now

The Replay Webhook action used to live on the claim detail page —
the old screenshot reflected that. It later moved to the row
hamburger on the claims list, but the menu item was missing entirely
until LakeEriePartners/stream#14380 restored it and
LakeEriePartners/stream#14381 exposed the
`tenant.new_claim_webhook_url` field that gated rendering.

Captured via the new webapp screenshot pipeline in #14381 — so future
re-shoots are one `npm run screenshots -- replay-claim-webhook`
away.

## Out of scope

- `static/img/replay-claim-webhook.png` is left in place; will sweep
  it alongside the other stale 0.7-era shots
  (`account-settings.png` etc.) when those pages get refreshed.

## Test plan

- [ ] Reviewer opens the deployed preview, confirms the new image
      shows the row hamburger menu with **Mark as Read /
      Recrawl Request / Replay Webhook** visible.
