### PR TITLE
docs(connect): refresh remaining webhook screenshots

### DIFF
--- a/docs/connect/webhooks-claim.md
+++ b/docs/connect/webhooks-claim.md
@@ -17,7 +17,7 @@ Stream.
 To edit the claim webhook URL, open **Account Settings** on the
 settings page.
 
-<img src="/img/account-settings.png" alt="Account settings" width="700" />
+<img src="https://tpastream-public.s3.amazonaws.com/webapp-docs/settings/account-settings.png" alt="Account settings" width="700" />
 
 You'll only see this setting if the claim webhook feature is enabled
 on your account. Once the webhook URL is set, all future posts go to

--- a/docs/connect/webhooks-crawl.md
+++ b/docs/connect/webhooks-crawl.md
@@ -33,12 +33,13 @@ like the [Claim Webhook URL](/connect/webhooks-claim#configuring-the-url).
 
 ## Replaying a crawl completion post
 
-<img src="/img/replay-crawl-webhook.png" alt="Replay crawl webhook" width="500" />
+<img src="https://tpastream-public.s3.amazonaws.com/webapp-docs/policy-holders/replay-crawl-webhook.png" alt="Replay crawl webhook" width="700" />
 
-To manually replay a first-completion webhook post, find the member
-on the member page. Under **Policy Holders**, there's a button to
-replay the webhook request. If the button isn't shown, verify that
-the feature is enabled and a URL is set.
+To manually replay a first-completion webhook post, open the
+**Policy Holders** page, find the policy holder, and pick
+**Retry First Crawl Completion Webhook** from the row action menu.
+If the option isn't shown, verify that the feature is enabled and a
+URL is set.
 
 The replay is useful for testing. If a crawl for that policy holder
 has not happened yet, the replay returns a failure. Note: replayed


### PR DESCRIPTION
## Summary

Refresh the remaining 0.7-era screenshots on `/connect/webhooks-claim`
and `/connect/webhooks-crawl` with fresh shots out of the webapp
screenshot pipeline in LakeEriePartners/stream#14381:

- `settings/account-settings.png` — Webhook Settings page with both
  URLs visible for the Sunny Benefits [DEV] tenant.
- `policy-holders/replay-crawl-webhook.png` — Policy Holders list
  with the row hamburger open and **Retry First Crawl Completion
  Webhook** in the menu.

URLs:
- https://tpastream-public.s3.amazonaws.com/webapp-docs/settings/account-settings.png
- https://tpastream-public.s3.amazonaws.com/webapp-docs/policy-holders/replay-crawl-webhook.png

## Also

The "Replaying a crawl completion post" step on `webhooks-crawl` said
to "find the member on the member page" and look "under Policy
Holders" — the action actually lives on the Policy Holders list
directly. Tightened so the instructions match the screenshot.

## Companion PRs

The unmanaged-shot inventory found one more stale screenshot in the
**SDK quickstart** doc (`employer-key-page.png`), which lives in the
SDK repo's own `docs/` tree and gets cloned into `docs/sdk/` at
docusaurus build time. Captured shot lives at
https://tpastream-public.s3.amazonaws.com/webapp-docs/employers/employer-key-page.png
and is wired up in TPAStream/stream-connect-js-sdk#99 — needs to land
on the SDK side for the rendered SDK section here to update.

There's also a sibling PR adding a `realtime-validation` shot to the
SDK capture pipeline + swapping its `<img>` ref:
TPAStream/stream-connect-js-sdk#100.

## Test plan

- [ ] Reviewer opens the deployed preview, confirms both refreshed
      shots load and show the expected UI state.
- [ ] Once SDK #99 + #100 merge and a fresh docusaurus build runs,
      confirm the SDK quickstart's Employer Key shot and sdk-flow's
      Realtime Validation shot also reflect the new URLs.
