### PR TITLE
Add payer_patient_id + DOB to claim webhook example

### DIFF
--- a/docs/connect/webhook-examples.md
+++ b/docs/connect/webhook-examples.md
@@ -115,6 +115,8 @@ the POST body, with `Content-Type: application/json`.
         "last_name": "Appleseed",
         "email": "sally@appleseed.com",
         "ssn": "999999999",
+        "payer_patient_id": "5a57ae867b66d87bfeaac2c5b98ed8dc",
+        "date_of_birth": "1985-06-12",
         "relationship": "spouse",
         "createddate": "2017-07-01T16:51:16.701956",
         "modifieddate": "2017-07-01T16:51:16.701956"
@@ -128,6 +130,8 @@ the POST body, with `Content-Type: application/json`.
     "amount_paid": null,
     "service_provider": "Salary.com",
     "patient_name": "Abram",
+    "patient_date_of_birth": "1985-06-12",
+    "payer_patient_id": "5a57ae867b66d87bfeaac2c5b98ed8dc",
     "policy_holder_id": 104
   }
 }

--- a/docs/connect/webhook-examples.md
+++ b/docs/connect/webhook-examples.md
@@ -115,8 +115,13 @@ the POST body, with `Content-Type: application/json`.
         "last_name": "Appleseed",
         "email": "sally@appleseed.com",
         "ssn": "999999999",
-        "payer_patient_id": "5a57ae867b66d87bfeaac2c5b98ed8dc",
         "date_of_birth": "1985-06-12",
+        "payer_identities": [
+          {
+            "payer_id": 1697,
+            "payer_patient_id": "5a57ae867b66d87bfeaac2c5b98ed8dc"
+          }
+        ],
         "relationship": "spouse",
         "createddate": "2017-07-01T16:51:16.701956",
         "modifieddate": "2017-07-01T16:51:16.701956"


### PR DESCRIPTION
Companion to LakeEriePartners/stream#14403 ([CRAWL-5552](https://tpastream.atlassian.net/browse/CRAWL-5552) + [CRAWL-5553](https://tpastream.atlassian.net/browse/CRAWL-5553)).

Stream now serializes these fields on the new-claim webhook payload (and the v3 claim API):

| Field | Where | What |
|---|---|---|
| `payer_patient_id` | claim and `dependents[]` | Anthem PAA FHIR Patient GUID. Stable across surname renderings; same GUID always resolves to the same dependent. Subscriber-claims carry the policy holder's GUID. |
| `patient_date_of_birth` | claim | Patient DOB on the claim row. |
| `date_of_birth` | `dependents[]` | Dependent DOB. Auto-populated from the claim's DOB on first match if the dependent row didn't have one. |

Example payload in `docs/connect/webhook-examples.md` updated so integrators see the shape they'll start receiving once #14403 lands.

## Related PRs

- LakeEriePartners/stream#14403 — [CRAWL-5552](https://tpastream.atlassian.net/browse/CRAWL-5552) + [CRAWL-5553](https://tpastream.atlassian.net/browse/CRAWL-5553): Anthem PAA GUID-primary dependent matching + DOB on outbound payloads
- LakeEriePartners/stream#14406 — [CRAWL-5538](https://tpastream.atlassian.net/browse/CRAWL-5538): scheme-less payer URLs rendering as relative links on crawl dashboard
- LakeEriePartners/stream#14407 — [CRAWL-5554](https://tpastream.atlassian.net/browse/CRAWL-5554): stop subscriber-MB-code stamping on Anthem PAA EOBs (follow-up to #14403)
- LakeEriePartners/developer-docs#28 — companion docs update for the new webhook fields in #14403
