### PR TITLE
Document the Connect API

### DIFF
--- a/docs/connect-api/authentication.md
+++ b/docs/connect-api/authentication.md
@@ -1,0 +1,167 @@
+---
+title: Connect API Authentication
+sidebar_label: Authentication
+---
+
+# Authentication
+
+The Connect API authenticates on two axes at once, and you need both on
+almost every request:
+
+1. **Which integration is calling** — your Connect token, in a header.
+2. **Which member the call is about** — the member's email address, in
+   the query string or the request body.
+
+There is no session, no cookie, and no login step. Every request carries
+everything it needs.
+
+## Base URL
+
+```
+https://app.tpastream.com/connect/v1
+```
+
+All requests must use HTTPS.
+
+:::note Legacy path
+`https://app.tpastream.com/sdk-api` serves the identical surface and
+remains supported indefinitely — it is what the JavaScript SDK uses.
+New server-side integrations should use `/connect/v1`, which is the
+path this documentation is written against and the one covered by the
+[stability commitment](/connect-api/overview#stability).
+:::
+
+## Headers
+
+| Header | Required | Value |
+|---|---|---|
+| `X-TPAStream-Token` | Yes | Your Connect token (the public one). |
+| `X-Connect-API-Version` | Yes | `1`. |
+| `Content-Type` | On writes | `application/json`. |
+| `X-Connect-Access-Token` | Conditional | A short-lived JWT minted from your secret key. Required for [`GET /fix-credentials`](/connect-api/reference#get-fix-credentials); optional but recommended elsewhere. |
+| `X-Tenant-Label` / `X-Tenant-Key` | Conditional | Your vendor label and tenant system key. Required if your token spans multiple tenants. |
+| `X-SDK-State-Id` | Conditional | An opaque string you generate per member session. Required only on the [Patient Access API](/connect-api/reference#patient-access-api) endpoints. |
+| `X-Is-Demo` | No | `1` to run against sandbox data. Omit or send `0` in production. |
+
+A minimal authenticated request:
+
+```bash
+curl https://app.tpastream.com/connect/v1/terms_of_service \
+  -H "X-TPAStream-Token: $TPA_CONNECT_TOKEN" \
+  -H "X-Connect-API-Version: 1" \
+  --data-urlencode "email=member@example.com" -G
+```
+
+## Identifying the member
+
+Every endpoint except the initial
+[`POST /tpastream_sdk`](/connect-api/reference#post-tpastream_sdk)
+must say which member the request concerns. Omitting it returns
+`403 Forbidden` with `Cannot provide empty user outside of initial post`.
+
+How you pass it depends on the verb:
+
+| Verb | Where the email goes |
+|---|---|
+| `GET` | `?email=member@example.com` |
+| `POST` / `PUT` | `user_email` at the top level of the JSON body, or `user.email` in a nested `user` object |
+
+The email must match a member your token has already bootstrapped via
+`POST /tpastream_sdk`. That call is the only one that may reference a
+member who doesn't exist yet — it creates them.
+
+## Your two keys
+
+If your integration uses the connect-access-token security model, you
+were issued two keys:
+
+- A **public token**. This is the `X-TPAStream-Token` value. It is not a
+  secret; the SDK ships it to browsers.
+- A **secret key**. This never leaves your infrastructure.
+
+The secret key mints short-lived access tokens:
+
+```bash
+curl -X POST https://app.tpastream.com/api/create-connect-token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connect_access_key": "'"$TPA_CONNECT_TOKEN"'",
+    "connect_secret_key": "'"$TPA_CONNECT_SECRET"'"
+  }'
+```
+
+```json
+{ "data": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }
+```
+
+Pass the result as `X-Connect-Access-Token`. It expires after one hour.
+
+Responses carry a rolling replacement in the
+`X-Set-Connect-Access-Token` response header — read it and use it on
+subsequent requests to avoid re-minting. If you let one expire, the next
+call fails with `422` and `"error_code": "expired_connect_token"`; mint a
+new one and retry.
+
+:::tip Server-side simplification
+The one-hour expiry and the rolling refresh exist so a browser can hold a
+usable credential without ever seeing your secret key. On a server that
+constraint doesn't apply. Minting a token per member session, or on
+demand when you see `expired_connect_token`, is simpler than tracking
+expiry and costs one extra request.
+:::
+
+## Do not share an HTTP client cookie jar
+
+This is the single most important operational detail on this page.
+
+The Connect API establishes a request-scoped identity for the member
+named in each request. Responses may set a session cookie as a byproduct.
+If your backend serves many members through one HTTP client with a
+**shared cookie jar**, a cookie set while handling member A can ride
+along on a request about member B.
+
+Configure your HTTP client to **discard cookies entirely**. Every request
+is independently authenticated by the headers and the member email, so
+there is nothing a cookie needs to carry.
+
+```python
+# Python — requests
+import requests
+
+session = requests.Session()
+session.cookies.set_policy(_BlockAll())  # or build a fresh request each time
+```
+
+```javascript
+// Node — undici / fetch: do not attach a CookieJar.
+// axios: set withCredentials: false (the default) and do not
+// install axios-cookiejar-support on this client.
+```
+
+If you are using an HTTP client that persists cookies by default, treat
+disabling that as a launch blocker, not a cleanup task.
+
+## Rate limits
+
+There are no per-token rate limits on the Connect API today. That is not
+an invitation to poll aggressively — see the
+[polling guidance](/connect-api/two-factor#polling-cadence) for the
+cadence we expect while a validation is in flight. We will publish limits
+before enforcing them.
+
+## Error responses
+
+Errors return a JSON body with a `message`, and sometimes a stable
+`error_code` you can branch on.
+
+| Status | Meaning |
+|---|---|
+| `400` | Malformed request, or a required header is missing. |
+| `401` | The token is inactive. Contact TPA Stream. |
+| `403` | Authenticated, but not permitted — most commonly a missing or unrecognized member email, or terms of use not accepted. |
+| `404` | No such record, or a malformed path parameter. |
+| `422` | Validation failed, or the connect access token is missing/expired. Check `error_code`. |
+| `500` | Our problem. Retry with backoff; if it persists, contact support with the `X-Request-Id` response header. |
+
+Always log the `X-Request-Id` response header. It is the fastest way for
+us to find your request in our logs.

--- a/docs/connect-api/overview.md
+++ b/docs/connect-api/overview.md
@@ -1,0 +1,134 @@
+---
+title: Connect API
+sidebar_label: Overview
+---
+
+# Connect API
+
+The Connect API is the HTTP contract behind the
+[Connect SDK](/connect/overview). It lets you run the carrier-connection
+flow — pick a carrier, submit credentials, complete multi-factor
+authentication, report status — from **your own backend**, with your own
+UI, without embedding our JavaScript.
+
+The SDK and the Connect API are two clients for the same product. Both
+talk to the same endpoints, create the same records, and trigger the same
+crawls. Nothing about a connection made through the Connect API is
+second-class.
+
+## Which one should you use?
+
+| Use the **SDK** when... | Use the **Connect API** when... |
+|---|---|
+| You want a working connect flow quickly and our wizard is close enough to your design. | You have a design system and want the connect flow rendered entirely by your own components. |
+| Credentials going straight from the member's browser to TPA Stream is what you want. | You already run a member-facing backend and would rather it broker the connection. |
+| Your app is primarily a web front end. | Your app is native mobile, or a server-rendered app where shipping our bundle is awkward. |
+| You don't want to own retry, state, or error handling. | You want the connection state machine in your own infrastructure, observable by your own tooling. |
+
+You can mix them. A tenant can run the SDK on one surface and the
+Connect API on another against the same token.
+
+:::note Not sure yet?
+If your only objection to the SDK is the visual design, look at
+[headless mode](/sdk/headless) first — it drops our stylesheet and lets
+you render the carrier picker, credentials form, and end screen with your
+own components while we keep the state machine. It's much less work than
+the Connect API. The Connect API is the right answer when you want the
+flow off your front end entirely, not just restyled.
+:::
+
+## What the flow looks like
+
+```
+ 1. POST /tpastream_sdk                    bootstrap the member, get carriers
+ 2. GET  /payer/{employer}/{payer}         get the carrier's credential form
+ 3. POST /policy_holder_sdk/policy_holder  submit credentials, get a task
+ 4. GET  /validate-credentials/{ph}/{task} poll until terminal
+      └─ if multi-factor is required:
+         PUT /validate-credentials/{ph}/{task}  {method}
+         PUT /validate-credentials/{ph}/{task}  {code}
+ 5. GET  /policy_holder_sdk/policy_holder/{ph}  confirm final state
+```
+
+Steps 3 and 4 are the interesting part and are covered in detail in
+[Multi-factor authentication](/connect-api/two-factor).
+
+Start with the [Quickstart](/connect-api/quickstart) for a working
+end-to-end walkthrough, or the
+[Endpoint reference](/connect-api/reference) if you already know the
+shape you want.
+
+## Two things you cannot move to your backend
+
+Be aware of these before you plan the integration. Neither is a
+limitation of the API; both are properties of how carriers work.
+
+### 1. Multi-factor authentication needs a live member
+
+Roughly a third of credential submissions across our customer base end
+up challenged by the carrier for a one-time code. When that happens the
+carrier is holding an authenticated session open and waiting. Your
+backend can own that session and drive it, but a real person still has to
+read a code off their phone and give it to you inside a bounded window.
+
+Practically, that means your front end needs a way to prompt the member
+and hand the code back to your server. It does not mean you need our UI —
+it means the interaction cannot be fully batched or deferred.
+
+### 2. Patient Access API carriers require a browser redirect
+
+Some carriers authenticate through their own OAuth flow rather than by
+accepting credentials. The member is sent to the carrier's website, signs
+in there, and is redirected back to your application with an access
+token in the query string. That redirect has to happen in a browser; there
+is no server-to-server equivalent.
+
+If you support these carriers you will need a small front-end step for
+them. See [Endpoint reference → Patient Access
+API](/connect-api/reference#patient-access-api).
+
+## What changes when credentials flow through your server
+
+With the SDK, carrier credentials go from the member's browser directly
+to TPA Stream. Your servers never see them. With the Connect API they
+pass through your infrastructure, which moves part of the compliance
+boundary onto you:
+
+- **Never log request bodies** on the credential-submit path, and audit
+  any framework-level request logging, APM tooling, or error reporter
+  that captures payloads by default.
+- **Never persist credentials.** Forward them and drop them. TPA Stream
+  stores what it needs to re-authenticate; you do not need a copy.
+- **Terms of use acceptance is yours to collect correctly.** The
+  `accept` and `tenants_accept` fields on the credential submit are the
+  member's affirmative consent. If you render your own form you are
+  representing that the member actually saw and accepted the terms.
+  Fetch them from
+  [`GET /terms_of_service`](/connect-api/reference#get-terms_of_service)
+  rather than reproducing the text yourself, so it stays current.
+
+Talk to your TPA Stream contact before going live if your business
+associate agreement predates this integration pattern.
+
+## Stability
+
+Endpoints, request shapes, and response fields documented in this
+section are covered by a compatibility commitment: we will not remove or
+rename them, and any new fields will be additive. Behavior not documented
+here — undocumented response fields, incidental ordering, exact error
+copy — may change without notice.
+
+If you need something the documented surface doesn't cover, ask rather
+than reverse-engineering it from network traces. Undocumented behavior
+you depend on is behavior we don't know we need to preserve.
+
+## Next
+
+- [Authentication](/connect-api/authentication) — tokens, headers, and
+  how each request identifies the member.
+- [Quickstart](/connect-api/quickstart) — a complete connection, start
+  to finish, in curl.
+- [Multi-factor authentication](/connect-api/two-factor) — the state
+  machine and how to drive it.
+- [Endpoint reference](/connect-api/reference) — every endpoint,
+  parameter, and response shape.

--- a/docs/connect-api/quickstart.md
+++ b/docs/connect-api/quickstart.md
@@ -1,0 +1,256 @@
+---
+title: Connect API Quickstart
+sidebar_label: Quickstart
+---
+
+# Quickstart
+
+A complete carrier connection, start to finish, in curl. Every call here
+is one your backend would make. Nothing in this walkthrough requires a
+browser except where noted.
+
+Set up your environment first:
+
+```bash
+export TPA_BASE=https://app.tpastream.com/connect/v1
+export TPA_CONNECT_TOKEN=...      # your public Connect token
+export TPA_MEMBER=member@example.com
+```
+
+And a helper so the examples stay readable:
+
+```bash
+tpa() { curl -sS -H "X-TPAStream-Token: $TPA_CONNECT_TOKEN" \
+                 -H "X-Connect-API-Version: 1" \
+                 -H "Content-Type: application/json" "$@"; }
+```
+
+## 1. Bootstrap the member
+
+This is the only call that may reference a member who doesn't exist yet.
+It creates or resolves the member, attaches them to the employer, and
+returns the carriers available to them.
+
+```bash
+tpa -X POST "$TPA_BASE/tpastream_sdk" -d '{
+  "system_key": "EMP-1234",
+  "vendor": "internal",
+  "employer_name": "Acme Corp",
+  "user_first_name": "Dana",
+  "user_last_name": "Reyes",
+  "user_email": "member@example.com",
+  "date_of_birth": "1985-04-12"
+}'
+```
+
+```json
+{
+  "data": {
+    "user": { "id": 90210, "email": "member@example.com" },
+    "employer": { "id": 203246, "name": "Acme Corp" },
+    "tenant": { "id": 1141, "name": "Acme Benefits" },
+    "payers": [
+      { "id": 6, "name": "UnitedHealthcare", "logo_url": "https://..." },
+      { "id": 116, "name": "Blue Cross Blue Shield of Massachusetts" }
+    ]
+  }
+}
+```
+
+Hold onto `employer.id` and `user.id`. You will need the employer id on
+almost every subsequent call.
+
+Render `payers` however you like — this is your carrier picker.
+
+## 2. Fetch the carrier's credential form
+
+Carriers ask for different things. Some want a username and password,
+some add a member id, a date of birth, or security questions. Rather than
+hard-coding per-carrier forms, fetch the schema:
+
+```bash
+tpa -G "$TPA_BASE/payer/203246/6" --data-urlencode "email=$TPA_MEMBER"
+```
+
+```json
+{
+  "data": {
+    "id": 6,
+    "name": "UnitedHealthcare",
+    "logo_url": "https://...",
+    "onboard_form": { "...": "JSON Schema describing the fields" },
+    "onboard_ui_schema": { "...": "presentation hints for those fields" },
+    "has_security_questions": false,
+    "supports_interoperability_apis": false,
+    "register_url": "https://www.myuhc.com/register",
+    "website_home_url_netloc": "myuhc.com"
+  }
+}
+```
+
+`onboard_form` is a JSON Schema. Drive your form from it and you get new
+carriers, and changes to existing ones, without a deploy.
+
+Two fields worth branching on:
+
+- `supports_interoperability_apis: true` means this carrier uses an OAuth
+  redirect instead of credentials. Skip to
+  [Patient Access API](/connect-api/reference#patient-access-api) —
+  the rest of this walkthrough does not apply.
+- `register_url` is where a member with no carrier account should be sent
+  to make one. Surface it near your form.
+
+## 3. Fetch the terms of use
+
+The member must accept before you can submit credentials. Fetch the
+current text rather than reproducing it:
+
+```bash
+tpa -G "$TPA_BASE/terms_of_service" --data-urlencode "email=$TPA_MEMBER"
+```
+
+```json
+{ "data": { "html_string": "<div>...</div>" } }
+```
+
+Render it, and collect two separate affirmative acknowledgements: the
+terms of use themselves, and consent for the tenant to access the
+account on the member's behalf. They map to `accept` and
+`tenants_accept` in the next step.
+
+## 4. Submit credentials
+
+```bash
+tpa -X POST "$TPA_BASE/policy_holder_sdk/policy_holder" -d '{
+  "user_email": "member@example.com",
+  "employer_id": 203246,
+  "payer_id": 6,
+  "username": "dreyes",
+  "password": "hunter2",
+  "date_of_birth": "1985-04-12",
+  "accept": true,
+  "tenants_accept": [1141]
+}'
+```
+
+Any additional fields the carrier's `onboard_form` declares go at the top
+level of this same object.
+
+```json
+{
+  "data": {
+    "policy_holder_id": 630364,
+    "task_id": "3bb088ed-cc38-4e0f-919f-f2060014ac44",
+    "task_token": "eyJhbGciOiJIUzI1NiIs..."
+  }
+}
+```
+
+Three things to note:
+
+- `accept` must be truthy and `tenants_accept` must be a **non-empty
+  array** of tenant ids. A string will be rejected. Missing either
+  returns `403`.
+- `task_id` identifies the validation now running against the carrier.
+  This is what you poll.
+- `task_token` is only needed if you subscribe to the
+  [event stream](/connect-api/two-factor#server-sent-events) instead of
+  polling. Server-side integrations generally should not.
+
+To **reconnect** an existing policy holder after a credential change,
+send the same body as a `PUT` to
+`/policy_holder_sdk/policy_holder/{policy_holder_id}`.
+
+## 5. Poll until the validation terminates
+
+```bash
+tpa -G "$TPA_BASE/validate-credentials/630364/3bb088ed-cc38-4e0f-919f-f2060014ac44" \
+    --data-urlencode "email=$TPA_MEMBER"
+```
+
+```json
+{ "data": { "id": "3bb088ed-...", "state": "PENDING" } }
+```
+
+Poll every 3 to 5 seconds. You will land on one of:
+
+| `state` | What it means | What to do |
+|---|---|---|
+| `PENDING` | Still working. | Keep polling. |
+| `WAITING_FOR_METHOD_CHOICE` | The carrier wants a one-time code and is offering delivery methods. | See [multi-factor](/connect-api/two-factor). |
+| `WAITING_FOR_TWO_FACTOR_CODE` | A code has been sent. | See [multi-factor](/connect-api/two-factor). |
+| `SUCCESS` | Validation finished. | Read `credentials_are_valid`. |
+| `FAILURE` | Validation could not complete. | Read `message` and surface it. |
+
+A terminal success:
+
+```json
+{
+  "data": {
+    "id": "3bb088ed-...",
+    "state": "SUCCESS",
+    "credentials_are_valid": true,
+    "pending": false
+  }
+}
+```
+
+`credentials_are_valid: true` means the carrier accepted the login.
+`pending: true` means we have not yet reached a verdict and will keep
+trying in the background — treat it as "accepted for now, check back",
+not as failure.
+
+Most connections that need a one-time code pass through here. Read
+[Multi-factor authentication](/connect-api/two-factor) before you ship;
+about a third of real connections hit it.
+
+## 6. Confirm the connection
+
+```bash
+tpa -G "$TPA_BASE/policy_holder_sdk/policy_holder/630364" \
+    --data-urlencode "employer_id=203246" \
+    --data-urlencode "email=$TPA_MEMBER"
+```
+
+```json
+{
+  "data": {
+    "policy_holder_id": 630364,
+    "uuid": "8d5f...",
+    "payer_id": 6,
+    "login_problem": null,
+    "login_needs_correction": false,
+    "last_successful_crawl_end": null,
+    "claims_synced_count": 0
+  }
+}
+```
+
+`login_problem: null` with `login_needs_correction: false` is a healthy
+connection. Claims will not be there yet — the first crawl runs
+asynchronously and can take a while. Subscribe to the
+[First Crawl Completion Webhook](/connect/webhooks-crawl) rather than
+polling for them.
+
+## 7. Show the member their connections
+
+For a "manage my carriers" screen:
+
+```bash
+tpa -G "$TPA_BASE/fix-credentials" --data-urlencode "email=$TPA_MEMBER" \
+    -H "X-Connect-Access-Token: $TPA_ACCESS_TOKEN"
+```
+
+Returns every policy holder for the member with its current status, so
+you can render reconnect prompts for the ones that need attention. This
+endpoint requires a
+[connect access token](/connect-api/authentication#your-two-keys).
+
+## Where to go next
+
+- [Multi-factor authentication](/connect-api/two-factor) — required
+  reading before launch.
+- [Endpoint reference](/connect-api/reference) — every parameter and
+  field.
+- [Claim webhook](/connect/webhooks-claim) — how connected members'
+  claims reach you.

--- a/docs/connect-api/reference.md
+++ b/docs/connect-api/reference.md
@@ -1,0 +1,271 @@
+---
+title: Connect API Reference
+sidebar_label: Endpoint reference
+---
+
+# Endpoint reference
+
+Base URL: `https://app.tpastream.com/connect/v1`
+
+Every request needs the headers described in
+[Authentication](/connect-api/authentication#headers). Every request
+except `POST /tpastream_sdk` must also
+[identify the member](/connect-api/authentication#identifying-the-member).
+
+All successful responses are wrapped in a `data` envelope:
+
+```json
+{ "data": { } }
+```
+
+## Endpoints at a glance
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/tpastream_sdk` | Bootstrap the member; list carriers |
+| `GET` | `/payer/{employer_id}/{payer_id}` | Carrier detail and credential schema |
+| `GET` | `/terms_of_service` | Current terms of use HTML |
+| `POST` | `/policy_holder_sdk/policy_holder` | Submit credentials, start validation |
+| `PUT` | `/policy_holder_sdk/policy_holder/{id}` | Resubmit credentials for an existing connection |
+| `GET` | `/policy_holder_sdk/policy_holder/{id}` | Connection status |
+| `GET` | `/validate-credentials/{ph_id}/{task_id}` | Validation state |
+| `PUT` | `/validate-credentials/{ph_id}/{task_id}` | Supply an MFA method or code |
+| `GET` | `/fix-credentials` | All of the member's connections |
+| `GET` `POST` | `/interop` | Patient Access API (OAuth carriers) |
+
+---
+
+## POST /tpastream_sdk
+
+Creates or resolves the member, attaches them to the employer, and
+returns the carriers available to them. The only endpoint that may
+reference a member who does not exist yet.
+
+**Body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `system_key` | string | Yes | Your identifier for the employer. |
+| `vendor` | string | Yes | Your vendor label. |
+| `employer_name` | string | Yes | Display name; used if the employer is being created. |
+| `user_email` | string | Yes | The member's email. Becomes their identity for every later call. |
+| `user_first_name` | string | Yes | |
+| `user_last_name` | string | Yes | |
+| `date_of_birth` | string | No | `YYYY-MM-DD`. |
+| `phone_number` | string | No | |
+| `member_system_key` | string | No | Your identifier for the member. |
+
+**Response** — `data.user`, `data.employer`, `data.tenant`,
+`data.payers` (array of `{id, name, logo_url}`).
+
+Safe to call repeatedly for the same member; it resolves rather than
+duplicating.
+
+---
+
+## GET /payer/\{employer_id\}/\{payer_id\}
+
+Carrier detail, including the schema for its credential form.
+
+**Query** — `email` (required), `referer` (optional, free-form
+attribution string).
+
+**Response**
+
+| Field | Notes |
+|---|---|
+| `id`, `name`, `logo_url` | Display basics. |
+| `onboard_form` | JSON Schema for the carrier's credential fields. |
+| `onboard_ui_schema` | Presentation hints for those fields. |
+| `has_security_questions` | Whether the carrier may ask security questions. |
+| `supports_interoperability_apis` | `true` means OAuth redirect, not credentials. See [Patient Access API](#patient-access-api). |
+| `register_url` | Where a member with no carrier account should sign up. |
+| `website_home_url_netloc` | The carrier's portal host, for display. |
+| `redirect_vendor_name` | Set when the carrier authenticates through a third party. |
+| `blogs` | Optional help articles: `id`, `title`, `article`. |
+
+Drive your form from `onboard_form` rather than hard-coding per-carrier
+fields, so carrier changes don't require a deploy.
+
+---
+
+## GET /terms_of_service
+
+**Query** — `email` (required).
+
+**Response** — `data.html_string`, the current terms of use as HTML.
+
+Fetch and render this rather than reproducing the text. The member's
+acceptance is recorded through `accept` and `tenants_accept` on the
+credential submit.
+
+---
+
+## POST /policy_holder_sdk/policy_holder
+
+Submits credentials, creates the connection, and dispatches a validation
+against the carrier.
+
+**Body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `user_email` | string | Yes | Identifies the member. May be supplied as `user.email` instead. |
+| `employer_id` | integer | Yes | From the bootstrap response. |
+| `payer_id` | integer | Yes | May also be supplied as `payer.id`. |
+| `username` | string | Usually | Whatever the carrier calls it. |
+| `password` | string | Usually | |
+| `date_of_birth` | string | Carrier-dependent | `YYYY-MM-DD`, or `null`. |
+| `member_id` | integer | No | Attach to a specific member record. |
+| `accept` | boolean | Yes | Member accepted the terms of use. Falsy returns `403`. |
+| `tenants_accept` | array | Yes | Non-empty array of tenant ids the member consented to. A string is rejected. |
+
+Any additional fields declared by the carrier's `onboard_form` go at the
+top level of the same object. They are validated against that schema;
+failures return `422` with per-field detail.
+
+**Response**
+
+| Field | Notes |
+|---|---|
+| `policy_holder_id` | The connection. Persist this. |
+| `task_id` | The running validation. Poll it. |
+| `task_token` | Only needed for the [event stream](/connect-api/two-factor#server-sent-events). |
+
+---
+
+## PUT /policy_holder_sdk/policy_holder/\{policy_holder_id\}
+
+Identical body and response to the `POST`. Use when the member is fixing
+credentials on a connection that already exists rather than making a new
+one.
+
+Changing `username` to one already used by another connection at the same
+carrier returns `403`.
+
+---
+
+## GET /policy_holder_sdk/policy_holder/\{policy_holder_id\}
+
+**Query** — `email` (required), `employer_id` (required).
+
+**Response**
+
+| Field | Notes |
+|---|---|
+| `policy_holder_id`, `uuid` | Identifiers. |
+| `payer_id` | The carrier. |
+| `login_problem` | `null` when healthy; otherwise names the issue. |
+| `login_needs_correction` | `true` when the member must act. |
+| `login_correction_message` | What to tell them. |
+| `last_successful_crawl_end` | Timestamp of the last successful data pull, or `null`. |
+| `claims_synced_count` | Claims retrieved so far. |
+| `most_recent_claim_date` | Date of the newest claim. |
+| `members` | `id`, `first_name`, `last_name`. |
+
+Note that `login_problem` and its siblings read as `null` while a
+validation is still running. Do not interpret an all-null response
+mid-validation as success — drive off the validation task instead.
+
+---
+
+## GET /validate-credentials/\{policy_holder_id\}/\{task_id\} {#get-validate-credentials}
+
+The polling endpoint. See
+[Multi-factor authentication](/connect-api/two-factor) for the full state
+machine.
+
+**Query** — `email` (required).
+
+**Response**
+
+| Field | Notes |
+|---|---|
+| `id` | The task id. |
+| `state` | See the [state table](/connect-api/two-factor#the-state-machine). |
+| `info` | Present on MFA states. Carries `method_list` on `WAITING_FOR_METHOD_CHOICE`. |
+| `credentials_are_valid` | On terminal states. `true` means the carrier accepted the login. |
+| `pending` | `true` means no verdict yet and we will keep trying. |
+| `message` | Member-safe explanation on failures and code rejections. |
+
+`message` is always safe to show a member. Internal error detail is never
+returned here.
+
+---
+
+## PUT /validate-credentials/\{policy_holder_id\}/\{task_id\}
+
+Supplies one piece of MFA input. Send exactly one of `method` or `code`
+per call.
+
+**Body**
+
+| Field | Type | Notes |
+|---|---|---|
+| `user_email` | string | Required. |
+| `method` | string | The exact string from `info.method_list`. |
+| `code` | string | The one-time code the member received. |
+
+Keep polling the `GET` after each call; this endpoint acknowledges the
+input rather than reporting the outcome.
+
+---
+
+## GET /fix-credentials
+
+Every connection belonging to the member, with current status. This is
+what a "manage my carriers" screen is built from.
+
+**Query** — `email` (required).
+**Headers** — requires
+[`X-Connect-Access-Token`](/connect-api/authentication#your-two-keys).
+
+**Response** — `data.user` with the member's policy holders and their
+status fields.
+
+---
+
+## Patient Access API
+
+Carriers with `supports_interoperability_apis: true` authenticate through
+their own OAuth flow instead of accepting credentials. The member signs
+in on the carrier's website and is redirected back to your application.
+
+**This step requires a browser.** There is no server-to-server
+equivalent, because the member authenticates directly with the carrier.
+
+Both endpoints require the `X-SDK-State-Id` header — an opaque string you
+generate per member session and reuse across the flow.
+
+### POST /interop
+
+**Body** — `user_email` (required).
+
+Begins the flow and returns the carrier authorization URL to send the
+member to.
+
+### GET /interop
+
+**Query** — `email` (required).
+
+Reports where the flow stands. Returns `status`, plus `ph_id` once a
+connection exists, or `error` if it failed.
+
+### The redirect back
+
+The carrier returns the member to your application with query
+parameters, notably `accessToken`. Strip these from the URL once read —
+leaving them in browser history is unnecessary exposure.
+
+Poll `GET /interop` after the redirect until `status` reports the
+connection is established, then treat `ph_id` like any other
+`policy_holder_id`.
+
+---
+
+## Response headers worth reading
+
+| Header | Notes |
+|---|---|
+| `X-Request-Id` | Log this. It is how we find your request in our logs. |
+| `X-Set-Connect-Access-Token` | A rolling replacement connect access token. Use it on subsequent requests instead of re-minting. |

--- a/docs/connect-api/two-factor.md
+++ b/docs/connect-api/two-factor.md
@@ -1,0 +1,177 @@
+---
+title: Multi-factor authentication
+sidebar_label: Multi-factor auth
+---
+
+# Multi-factor authentication
+
+Most carriers challenge a credential submission with a one-time code at
+least some of the time. Across our customer base this is roughly a third
+of connection attempts, so treat it as a normal path rather than an edge
+case — an integration that only handles the happy path will fail for a
+large minority of your members.
+
+While a validation waits on a code, the carrier is holding an
+authenticated session open. That session has a limited lifetime. This is
+the one place in the Connect API where a real person has to act inside a
+bounded window.
+
+## The state machine
+
+After you submit credentials you have a `task_id`. Poll
+[`GET /validate-credentials/{policy_holder_id}/{task_id}`](/connect-api/reference#get-validate-credentials)
+and drive off `state`:
+
+```
+        POST credentials
+               │
+               ▼
+          ┌─────────┐
+          │ PENDING │◄──────────────┐
+          └────┬────┘               │
+               │                    │
+   no MFA ─────┼───── MFA required  │
+      │        │                    │
+      │        ▼                    │
+      │  WAITING_FOR_METHOD_CHOICE  │
+      │        │                    │
+      │        │ PUT {method}       │
+      │        ▼                    │
+      │  TRIGGERING_TWO_FACTOR_AUTH ┤  (carrier is sending the code)
+      │        │                    │
+      │        ▼                    │
+      │  WAITING_FOR_TWO_FACTOR_CODE│
+      │        │                    │
+      │        │ PUT {code}         │
+      │        ▼                    │
+      │  ENTERING_CODE ─────────────┘  (wrong code returns here
+      │        │                        with a message)
+      │        ▼
+      │  TWO_FACTOR_AUTH_COMPLETE
+      │        │
+      ▼        ▼
+    SUCCESS / FAILURE
+```
+
+| State | Terminal | Meaning |
+|---|---|---|
+| `PENDING` | No | Working. Also reported for the underlying `STARTED` and `RETRY` states. |
+| `WAITING_FOR_METHOD_CHOICE` | No | The carrier offers several delivery methods. `info.method_list` holds them. |
+| `TRIGGERING_TWO_FACTOR_AUTH` | No | We asked the carrier to send the code. |
+| `WAITING_FOR_TWO_FACTOR_CODE` | No | The code is on its way to the member. |
+| `ENTERING_CODE` | No | We are submitting the code you supplied. |
+| `TWO_FACTOR_AUTH_COMPLETE` | No | The code was accepted. `SUCCESS` follows shortly. |
+| `SUCCESS` | Yes | Finished. Read `credentials_are_valid`. |
+| `FAILURE` | Yes | Could not complete. Read `message`. |
+
+## Choosing a delivery method
+
+When you poll into `WAITING_FOR_METHOD_CHOICE`:
+
+```json
+{
+  "data": {
+    "id": "3bb088ed-...",
+    "state": "WAITING_FOR_METHOD_CHOICE",
+    "info": { "method_list": ["Text to (***) ***-1234", "Email to d***@example.com"] }
+  }
+}
+```
+
+`method_list` is carrier-authored text. Show the strings as-is; do not
+try to normalize them into your own categories, and do not assume SMS is
+always present or always first.
+
+Send back the exact string the member picked:
+
+```bash
+tpa -X PUT "$TPA_BASE/validate-credentials/630364/3bb088ed-..." -d '{
+  "user_email": "member@example.com",
+  "method": "Text to (***) ***-1234"
+}'
+```
+
+Then keep polling. You will move through `TRIGGERING_TWO_FACTOR_AUTH`
+into `WAITING_FOR_TWO_FACTOR_CODE`.
+
+Some carriers offer only one method and skip this state entirely, going
+straight to `WAITING_FOR_TWO_FACTOR_CODE`. Handle both.
+
+## Submitting the code
+
+```bash
+tpa -X PUT "$TPA_BASE/validate-credentials/630364/3bb088ed-..." -d '{
+  "user_email": "member@example.com",
+  "code": "482915"
+}'
+```
+
+Same endpoint, different key. Keep polling afterward.
+
+If the carrier rejects the code — wrong digits, expired, mistyped — the
+state returns to `WAITING_FOR_TWO_FACTOR_CODE` with a `message`
+explaining why. Surface that message and let the member try again. Do
+**not** restart the credential submission; the carrier session is still
+open and a fresh submit will send a second code and confuse the member.
+
+## Polling cadence
+
+| Situation | Interval |
+|---|---|
+| Right after credential submit | 3 seconds |
+| Waiting on the member to pick a method or type a code | 5 seconds |
+| Anything past 2 minutes on the same state | 10 seconds |
+
+Stop polling once you reach `SUCCESS` or `FAILURE`. There is no reason
+to poll a terminal task, and no new information will arrive.
+
+## Designing the member experience
+
+Your front end has to prompt the member and get the code back to your
+server. The specific transport is up to you — a polled endpoint on your
+own API, a websocket, a server-sent stream, or a plain form post all
+work. What matters:
+
+- **Do not block your UI on the whole flow.** The member may need a
+  minute to find their phone. Let them do other things; surface the
+  prompt when it arrives.
+- **Show carrier text verbatim.** Method labels and rejection messages
+  come from the carrier and are usually more accurate than anything you
+  would write.
+- **Let them retry the code without starting over.** This is the most
+  common recoverable failure in the whole flow.
+- **Handle the member walking away.** Decide what your UI does when a
+  validation is left hanging, and make sure the member can start a fresh
+  attempt later.
+
+## Server-sent events
+
+There is also an event stream:
+
+```
+GET https://app.tpastream.com/v3/sdk/progress/{task_id}/stream?token={task_token}
+```
+
+It pushes the same state transitions as they happen, authenticated by the
+`task_token` returned alongside `task_id` on the credential submit.
+
+**We recommend polling instead for server-side integrations.** The stream
+was built for browsers and carries browser-shaped constraints: the
+`task_token` is valid for about ten minutes, and the server closes the
+stream after roughly the same interval with a `timeout` event. A member
+who takes longer than that to find their phone will outlive the stream.
+The polling endpoint has neither limit and is authenticated the same way
+as every other call.
+
+If a stream does close on you, the underlying validation is unaffected —
+it keeps running, and polling will show you where it landed.
+
+## Failure modes worth handling
+
+| Symptom | Cause | Response |
+|---|---|---|
+| `FAILURE` immediately after submit | Credentials rejected outright. | Show `message`, let the member re-enter. |
+| Stuck in `PENDING` past a few minutes | Carrier is slow or degraded. | Keep polling, but tell the member it's taking a while. |
+| `WAITING_FOR_TWO_FACTOR_CODE` with a `message` | The previous code was rejected. | Show the message, accept another code. |
+| `SUCCESS` with `credentials_are_valid: false` | The carrier authenticated but the account has a problem. | Check `login_problem` on the policy holder. |
+| `SUCCESS` with `pending: true` | No verdict yet; we will keep trying in the background. | Treat as provisional success, not failure. |

--- a/docs/connect/overview.md
+++ b/docs/connect/overview.md
@@ -15,6 +15,13 @@ options, lifecycle callbacks, error handling, MFA, theming), see the
 [SDK Reference](/sdk/), which is generated from the SDK repository's
 own docs at the version pinned in this build.
 
+:::tip Prefer to run the flow from your own backend?
+The SDK is one client for the Connect product; the
+[Connect API](/connect-api/overview) is the other. It exposes the same
+carrier-connection flow as plain HTTP so you can render the UI with your
+own components and keep the state machine on your servers.
+:::
+
 ## What it does
 
 - Renders a wizard that lets the member pick their carrier, enter

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -20,6 +20,18 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "Connect API",
+      link: { type: "doc", id: "connect-api/overview" },
+      collapsed: false,
+      items: [
+        "connect-api/authentication",
+        "connect-api/quickstart",
+        "connect-api/two-factor",
+        "connect-api/reference",
+      ],
+    },
+    {
+      type: "category",
       label: "REST API",
       link: { type: "doc", id: "api/overview" },
       collapsed: false,


### PR DESCRIPTION
## Why

HealthLock asked for documentation on driving the carrier-connection flow from their backend instead of embedding the Connect SDK. The endpoints already support that, but nothing about them is documented and `/sdk-api` is absent from the public OpenAPI spec, so there was nothing to point them at.

This documents the surface as a first-class integration path: same product as the SDK, different client.

## What's here

Five pages under a new "Connect API" sidebar category:

- **Overview** — when to use this vs the SDK vs headless mode, what changes when credentials transit the customer's infrastructure, and the two things that genuinely cannot move server-side.
- **Authentication** — headers, the two-key model, how each request identifies the member, error codes.
- **Quickstart** — a complete connection end to end in curl, from bootstrap through confirmation.
- **Multi-factor auth** — the state machine, both `PUT` shapes, polling cadence, failure modes.
- **Endpoint reference** — all ten endpoints with parameters and response fields.

Also adds a pointer from the Connect SDK overview so someone landing there who wants the backend path finds it.

## Things I made a point of putting up front

**The cookie-jar warning** gets its own section rather than a footnote, flagged as a launch blocker. A backend serving many members through one HTTP client with a shared cookie jar is the worst failure mode available on this surface, and it's the kind of thing nobody discovers until it's a support ticket about crossed member data.

**Polling is recommended over SSE** for server-side callers. The `task_token` is good for about ten minutes and the stream carries a ~600s server deadline; both are browser-shaped constraints a backend has no reason to inherit, and a member hunting for their phone will routinely outlive them.

**The two things that can't move server-side** are in the overview, not buried in the reference. Patient Access API carriers need a browser redirect, and roughly a third of credential submissions get challenged for a one-time code, so a real person has to act inside a bounded window. Better they hit both on page one than in week three.

**The PHI trust boundary** — with the SDK, credentials go browser to TPA Stream and never touch the customer's servers. With this they don't, which moves part of the compliance surface onto the integrator: don't log bodies, don't persist, and terms-of-use acceptance becomes theirs to collect correctly.

## Naming

The base path is documented as `https://app.tpastream.com/connect/v1`, with `/sdk-api` noted as the supported legacy path the SDK uses.

`connect` matches vocabulary that already exists everywhere — this site's "Connect SDK" category, the `stream-connect-sdk` package, connect tokens, `/api/create-connect-token` — so "Connect API" makes the relationship self-evident. The version sits after the product rather than before it so it doesn't collide with `/v3`, which is an internal stack-generation marker rather than an API version and would be confusing as the first public version of a brand-new contract.

## Blocked on

The `/connect/v1` path is an alias that doesn't exist yet. It ships in LakeEriePartners/stream#15047 along with the `X-Connect-API-Version` header these docs use. **This should not merge before that one.**

## Testing

`npm run build` passes. No broken links or anchors from any new page — the three warnings in the build output are all pre-existing (`/connect/origin-policy`, `/api-reference/get-v-2-mailgun-webhook`, `/sdk/faq`).
