### PR TITLE
Connect API: make SSE the documented path, fix the invented guidance

### DIFF
--- a/docs/connect-api/authentication.md
+++ b/docs/connect-api/authentication.md
@@ -144,10 +144,10 @@ disabling that as a launch blocker, not a cleanup task.
 ## Rate limits
 
 There are no per-token rate limits on the Connect API today. That is not
-an invitation to poll aggressively — see the
-[polling guidance](/connect-api/two-factor#polling-cadence) for the
-cadence we expect while a validation is in flight. We will publish limits
-before enforcing them.
+an invitation to hammer the API — prefer the
+[event stream](/connect-api/two-factor#watching-progress-server-sent-events)
+for watching validations, and keep any polling to a few-second cadence.
+We will publish limits before enforcing them.
 
 ## Error responses
 

--- a/docs/connect-api/overview.md
+++ b/docs/connect-api/overview.md
@@ -43,7 +43,7 @@ flow off your front end entirely, not just restyled.
  1. POST /tpastream_sdk                    bootstrap the member, get carriers
  2. GET  /payer/{employer}/{payer}         get the carrier's credential form
  3. POST /policy_holder_sdk/policy_holder  submit credentials, get a task
- 4. GET  /validate-credentials/{ph}/{task} poll until terminal
+ 4.      /v3/sdk/progress/{task}/stream    watch progress (SSE; polling GET also works)
       └─ if multi-factor is required:
          PUT /validate-credentials/{ph}/{task}  {method}
          PUT /validate-credentials/{ph}/{task}  {code}
@@ -69,7 +69,8 @@ Roughly a third of credential submissions across our customer base end
 up challenged by the carrier for a one-time code. When that happens the
 carrier is holding an authenticated session open and waiting. Your
 backend can own that session and drive it, but a real person still has to
-read a code off their phone and give it to you inside a bounded window.
+read a code off their phone and give it to you — the validation allows
+about five minutes per prompt before giving up.
 
 Practically, that means your front end needs a way to prompt the member
 and hand the code back to your server. It does not mean you need our UI —

--- a/docs/connect-api/quickstart.md
+++ b/docs/connect-api/quickstart.md
@@ -152,16 +152,30 @@ Three things to note:
   array** of tenant ids. A string will be rejected. Missing either
   returns `403`.
 - `task_id` identifies the validation now running against the carrier.
-  This is what you poll.
-- `task_token` is only needed if you subscribe to the
-  [event stream](/connect-api/two-factor#server-sent-events) instead of
-  polling. Server-side integrations generally should not.
+  This is what you watch.
+- `task_token` authenticates the
+  [event stream](/connect-api/two-factor#watching-progress-server-sent-events)
+  subscription for this validation. It is short-lived by design; a fresh
+  one is minted every time you GET the policy holder while the
+  validation is running.
 
 To **reconnect** an existing policy holder after a credential change,
 send the same body as a `PUT` to
 `/policy_holder_sdk/policy_holder/{policy_holder_id}`.
 
-## 5. Poll until the validation terminates
+## 5. Watch the validation
+
+The credential submit returned a `task_id` and a `task_token`.
+Subscribe to the event stream and states arrive as they happen:
+
+```bash
+curl -N "https://app.tpastream.com/v3/sdk/progress/3bb088ed-cc38-4e0f-919f-f2060014ac44/stream?token=$TASK_TOKEN"
+```
+
+Each connection is capped at ~10 minutes; on the `timeout` event,
+re-fetch the policy holder for a fresh `task_token` and resubscribe —
+the [MFA page](/connect-api/two-factor#reattaching) has the loop.
+Prefer not to hold streams open? Polling works too:
 
 ```bash
 tpa -G "$TPA_BASE/validate-credentials/630364/3bb088ed-cc38-4e0f-919f-f2060014ac44" \
@@ -172,11 +186,11 @@ tpa -G "$TPA_BASE/validate-credentials/630364/3bb088ed-cc38-4e0f-919f-f2060014ac
 { "data": { "id": "3bb088ed-...", "state": "PENDING" } }
 ```
 
-Poll every 3 to 5 seconds. You will land on one of:
+Either way, you will land on one of:
 
 | `state` | What it means | What to do |
 |---|---|---|
-| `PENDING` | Still working. | Keep polling. |
+| `PENDING` | Still working. | Keep watching. |
 | `WAITING_FOR_METHOD_CHOICE` | The carrier wants a one-time code and is offering delivery methods. | See [multi-factor](/connect-api/two-factor). |
 | `WAITING_FOR_TWO_FACTOR_CODE` | A code has been sent. | See [multi-factor](/connect-api/two-factor). |
 | `SUCCESS` | Validation finished. | Read `credentials_are_valid`. |

--- a/docs/connect-api/reference.md
+++ b/docs/connect-api/reference.md
@@ -130,7 +130,7 @@ failures return `422` with per-field detail.
 |---|---|
 | `policy_holder_id` | The connection. Persist this. |
 | `task_id` | The running validation. Poll it. |
-| `task_token` | Only needed for the [event stream](/connect-api/two-factor#server-sent-events). |
+| `task_token` | Only needed for the [event stream](/connect-api/two-factor#watching-progress-server-sent-events). |
 
 ---
 
@@ -171,7 +171,8 @@ mid-validation as success — drive off the validation task instead.
 
 ## GET /validate-credentials/\{policy_holder_id\}/\{task_id\} {#get-validate-credentials}
 
-The polling endpoint. See
+Point-in-time validation state — the polling alternative to the
+[event stream](#event-stream). See
 [Multi-factor authentication](/connect-api/two-factor) for the full state
 machine.
 
@@ -206,10 +207,31 @@ per call.
 | `method` | string | The exact string from `info.method_list`. |
 | `code` | string | The one-time code the member received. |
 
-Keep polling the `GET` after each call; this endpoint acknowledges the
+Keep watching the state after each call; this endpoint acknowledges the
 input rather than reporting the outcome.
 
 ---
+
+## Event stream {#event-stream}
+
+```
+GET https://app.tpastream.com/v3/sdk/progress/{task_id}/stream?token={task_token}
+```
+
+Server-sent events for one validation task. Note the base URL: this
+endpoint lives under `/v3/sdk`, not under the Connect API prefix, and
+authenticates with the `task_token` from the credential submit instead
+of the usual headers.
+
+Events: `state` (task status + stage data), `ping` (heartbeat,
+~15s), `timeout` (per-connection ~10-minute cap reached — re-fetch the
+policy holder for a fresh `task_token` and resubscribe). The stream
+closes itself after a terminal state. A subscribe attempt that returns
+`401` `Task not available` means the validation already finished; read
+the result via the GET above.
+
+Full usage, including the reattach loop:
+[Multi-factor authentication](/connect-api/two-factor#watching-progress-server-sent-events).
 
 ## GET /fix-credentials
 

--- a/docs/connect-api/two-factor.md
+++ b/docs/connect-api/two-factor.md
@@ -12,15 +12,18 @@ case — an integration that only handles the happy path will fail for a
 large minority of your members.
 
 While a validation waits on a code, the carrier is holding an
-authenticated session open. That session has a limited lifetime. This is
-the one place in the Connect API where a real person has to act inside a
-bounded window.
+authenticated session open, so the validation will not wait forever:
+**the member has about five minutes at each interactive step** (picking
+a delivery method, entering the code) before the validation gives up
+and the connection is marked as needing member attention. That number —
+not any transport detail — is the constraint to design your prompt UX
+around.
 
 ## The state machine
 
-After you submit credentials you have a `task_id`. Poll
-[`GET /validate-credentials/{policy_holder_id}/{task_id}`](/connect-api/reference#get-validate-credentials)
-and drive off `state`:
+After you submit credentials you have a `task_id`. Watch its `state`
+— over the [event stream](#watching-progress-server-sent-events) or by
+[polling](#polling-as-a-fallback) — and drive off it:
 
 ```
         POST credentials
@@ -66,7 +69,7 @@ and drive off `state`:
 
 ## Choosing a delivery method
 
-When you poll into `WAITING_FOR_METHOD_CHOICE`:
+When the state reaches `WAITING_FOR_METHOD_CHOICE`:
 
 ```json
 {
@@ -91,8 +94,9 @@ tpa -X PUT "$TPA_BASE/validate-credentials/630364/3bb088ed-..." -d '{
 }'
 ```
 
-Then keep polling. You will move through `TRIGGERING_TWO_FACTOR_AUTH`
-into `WAITING_FOR_TWO_FACTOR_CODE`.
+Then keep watching. You will move through `TRIGGERING_TWO_FACTOR_AUTH`
+into `WAITING_FOR_TWO_FACTOR_CODE`. From the moment the method list is
+offered, the member has about five minutes to pick one.
 
 Some carriers offer only one method and skip this state entirely, going
 straight to `WAITING_FOR_TWO_FACTOR_CODE`. Handle both.
@@ -106,24 +110,15 @@ tpa -X PUT "$TPA_BASE/validate-credentials/630364/3bb088ed-..." -d '{
 }'
 ```
 
-Same endpoint, different key. Keep polling afterward.
+Same endpoint, different key. Keep watching afterward. The five-minute
+clock applies here too: once the carrier sends the code, the member has
+about five minutes to supply it.
 
 If the carrier rejects the code — wrong digits, expired, mistyped — the
 state returns to `WAITING_FOR_TWO_FACTOR_CODE` with a `message`
 explaining why. Surface that message and let the member try again. Do
 **not** restart the credential submission; the carrier session is still
 open and a fresh submit will send a second code and confuse the member.
-
-## Polling cadence
-
-| Situation | Interval |
-|---|---|
-| Right after credential submit | 3 seconds |
-| Waiting on the member to pick a method or type a code | 5 seconds |
-| Anything past 2 minutes on the same state | 10 seconds |
-
-Stop polling once you reach `SUCCESS` or `FAILURE`. There is no reason
-to poll a terminal task, and no new information will arrive.
 
 ## Designing the member experience
 
@@ -144,34 +139,77 @@ work. What matters:
   validation is left hanging, and make sure the member can start a fresh
   attempt later.
 
-## Server-sent events
+## Watching progress: server-sent events
 
-There is also an event stream:
+The recommended way to watch a validation is the event stream — states
+arrive as they happen, with nothing to poll:
 
 ```
 GET https://app.tpastream.com/v3/sdk/progress/{task_id}/stream?token={task_token}
 ```
 
-It pushes the same state transitions as they happen, authenticated by the
-`task_token` returned alongside `task_id` on the credential submit.
+Authentication is the `task_token` returned alongside `task_id` on the
+credential submit — a short-lived JWT bound to that one task. From curl:
 
-**We recommend polling instead for server-side integrations.** The stream
-was built for browsers and carries browser-shaped constraints: the
-`task_token` is valid for about ten minutes, and the server closes the
-stream after roughly the same interval with a `timeout` event. A member
-who takes longer than that to find their phone will outlive the stream.
-The polling endpoint has neither limit and is authenticated the same way
-as every other call.
+```bash
+curl -N "https://app.tpastream.com/v3/sdk/progress/$TASK_ID/stream?token=$TASK_TOKEN"
+```
 
-If a stream does close on you, the underlying validation is unaffected —
-it keeps running, and polling will show you where it landed.
+Three event types arrive:
+
+| Event | Payload | Meaning |
+|---|---|---|
+| `state` | The task's current status and result data | Drive your state machine off this. |
+| `ping` | `{}` | Heartbeat every ~15s. Ignore. |
+| `timeout` | `{}` | This *connection* hit its ~10-minute cap. Resubscribe (below). The validation is unaffected. |
+
+`state` events carry the raw task metadata: `status` is the state name
+from the table above, and `result` holds the stage's data (for
+`WAITING_FOR_METHOD_CHOICE`, `result.method_list` is the delivery-method
+list). Treat any status you don't recognize as "still working".
+
+### Reattaching
+
+Each stream connection is capped at about ten minutes, and each
+`task_token` is scoped to roughly one connection — but the validation
+stays subscribable for its entire lifetime. When you receive `timeout`
+(or lose the connection):
+
+1. `GET /policy_holder_sdk/policy_holder/{id}` — while the validation
+   is alive, the response includes the active `task_id` and a **fresh
+   `task_token`**.
+2. Resubscribe to the stream with the new token.
+
+If a resubscribe fails with `401` and `Task not available`, the
+validation has reached a terminal state — read the outcome with
+[`GET /validate-credentials/...`](/connect-api/reference#get-validate-credentials)
+(or the policy-holder GET) rather than retrying the stream.
+
+One practical shortcut: for connection UX you can stop streaming at
+`TWO_FACTOR_AUTH_COMPLETE`. The task keeps running well past it —
+retrieving the member's claims can take a long while — but the answer
+your member is waiting for (did the connection work?) is already known,
+and claims reach you via the
+[claim webhook](/connect/webhooks-claim), not the stream.
+
+## Polling as a fallback
+
+If you'd rather not hold streams open,
+[`GET /validate-credentials/{policy_holder_id}/{task_id}`](/connect-api/reference#get-validate-credentials)
+returns the same states. Poll it every few seconds while a validation
+is in flight and stop on `SUCCESS` / `FAILURE`. It is authenticated
+like every other Connect API call and needs no `task_token`. Both
+transports are supported; pick whichever fits your architecture.
 
 ## Failure modes worth handling
 
 | Symptom | Cause | Response |
 |---|---|---|
 | `FAILURE` immediately after submit | Credentials rejected outright. | Show `message`, let the member re-enter. |
-| Stuck in `PENDING` past a few minutes | Carrier is slow or degraded. | Keep polling, but tell the member it's taking a while. |
+| Stuck in `PENDING` past a few minutes | Carrier is slow or degraded. | Keep watching, but tell the member it's taking a while. |
+| `WAITING_FOR_METHOD_CHOICE` / `WAITING_FOR_TWO_FACTOR_CODE` ends in `FAILURE` with no input sent | The member ran out the ~5-minute window at that stage. | The connection is marked as needing attention; let the member start a fresh attempt. |
+| Stream emits `timeout` | That connection hit its ~10-minute cap. | [Reattach](#reattaching); the validation is unaffected. |
+| Resubscribe returns `401` `Task not available` | The validation reached a terminal state. | Read the outcome via the GET; don't retry the stream. |
 | `WAITING_FOR_TWO_FACTOR_CODE` with a `message` | The previous code was rejected. | Show the message, accept another code. |
 | `SUCCESS` with `credentials_are_valid: false` | The carrier authenticated but the account has a problem. | Check `login_problem` on the policy holder. |
 | `SUCCESS` with `pending: true` | No verdict yet; we will keep trying in the background. | Treat as provisional success, not failure. |


### PR DESCRIPTION
## Why

Steve challenged the two-factor page's polling-over-SSE stance — including a polling-cadence table whose numbers turned out to be invented during drafting — and the challenge held up all the way down. The ~10-minute SSE ceiling the page blamed was not inherent to the transport: it was three Redis pointer TTLs sized to one stream connection instead of the task, fixed in LakeEriePartners/stream#15065. With reattach working across the whole validation lifetime, SSE is simply the better transport for watching a validation, and it's what HealthLock (the integrator these docs were written for) explicitly asked for in the 2026-07-16 sync.

## What changed

- **two-factor.md** — "Watching progress: server-sent events" is now the primary section: the three event types, the reattach loop (`timeout` → PH GET re-mints `task_token` → resubscribe; `401 Task not available` ⇒ the task finished, read the result via GET), and the practical shortcut of stopping at `TWO_FACTOR_AUTH_COMPLETE` since claims arrive by webhook anyway. Polling is a short fallback section. The cadence table is deleted, not replaced — there was never a real basis for tiered intervals.
- **The real member constraint is now the headline**, and it was missing entirely before: the validation waits about five minutes per interactive MFA stage (`two_factor_limit` in `stream/services/crawl_task.py`) before giving up and marking the connection as needing attention. That — not any transport window — is what prompt UX must be designed around. Added to the intro, the failure-modes table, and the overview's MFA section.
- **quickstart.md** step 5: `curl -N` subscribe first, polling as the alternative.
- **reference.md**: the event stream gets a proper endpoint section (distinct base path and auth called out); the validate-credentials GET is reframed as the polling alternative.
- **authentication.md**: the rate-limits section pointed at the now-dead `#polling-cadence` anchor; re-aimed.

## Gating

**Do not merge before LakeEriePartners/stream#15065 is live in prod.** The reattach behavior these pages describe (resubscribe beyond ten minutes, `401` ⇒ terminal) depends on that TTL change. Note the previous docs deploy sat behind a stalled `prod/db-migrate` for a while — worth confirming the stream PR has actually rolled, not just merged, before this one lands.

## Testing

`npm run build` exits 0 with no broken links or anchors from any `connect-api` page (the three pre-existing warnings elsewhere are unchanged).
