### PR TITLE
Connect API docs: clean route spellings throughout

### DIFF
--- a/docs/connect-api/authentication.md
+++ b/docs/connect-api/authentication.md
@@ -26,8 +26,11 @@ All requests must use HTTPS.
 :::note Legacy path
 `https://app.tpastream.com/sdk-api` serves the identical surface and
 remains supported indefinitely — it is what the JavaScript SDK uses.
-New server-side integrations should use `/connect/v1`, which is the
-path this documentation is written against and the one covered by the
+The SDK-era route spellings (`/bootstrap` was `/tpastream_sdk`,
+`/policy_holder` was `/policy_holder_sdk/policy_holder`, and
+`X-Connect-State-Id` was `X-SDK-State-Id`) likewise remain valid
+aliases. New integrations should use `/connect/v1` and the names in
+these pages — that is the contract covered by the
 [stability commitment](/connect-api/overview#stability).
 :::
 
@@ -40,7 +43,7 @@ path this documentation is written against and the one covered by the
 | `Content-Type` | On writes | `application/json`. |
 | `X-Connect-Access-Token` | Conditional | A short-lived JWT minted from your secret key. Required for [`GET /fix-credentials`](/connect-api/reference#get-fix-credentials); optional but recommended elsewhere. |
 | `X-Tenant-Label` / `X-Tenant-Key` | Conditional | Your vendor label and tenant system key. Required if your token spans multiple tenants. |
-| `X-SDK-State-Id` | Conditional | An opaque string you generate per member session. Required only on the [Patient Access API](/connect-api/reference#patient-access-api) endpoints. |
+| `X-Connect-State-Id` | Conditional | An opaque string you generate per member session. Required only on the [Patient Access API](/connect-api/reference#patient-access-api) endpoints. |
 | `X-Is-Demo` | No | `1` to run against sandbox data. Omit or send `0` in production. |
 
 A minimal authenticated request:
@@ -55,7 +58,7 @@ curl https://app.tpastream.com/connect/v1/terms_of_service \
 ## Identifying the member
 
 Every endpoint except the initial
-[`POST /tpastream_sdk`](/connect-api/reference#post-tpastream_sdk)
+[`POST /bootstrap`](/connect-api/reference#post-bootstrap)
 must say which member the request concerns. Omitting it returns
 `403 Forbidden` with `Cannot provide empty user outside of initial post`.
 
@@ -67,7 +70,7 @@ How you pass it depends on the verb:
 | `POST` / `PUT` | `user_email` at the top level of the JSON body, or `user.email` in a nested `user` object |
 
 The email must match a member your token has already bootstrapped via
-`POST /tpastream_sdk`. That call is the only one that may reference a
+`POST /bootstrap`. That call is the only one that may reference a
 member who doesn't exist yet — it creates them.
 
 ## Your two keys

--- a/docs/connect-api/overview.md
+++ b/docs/connect-api/overview.md
@@ -31,20 +31,20 @@ taking on.
 ## What the flow looks like
 
 ```
- 1. POST /tpastream_sdk                    bootstrap the member, get carriers
+ 1. POST /bootstrap                        create or resolve the member, get carriers
  2. GET  /payer/{employer}/{payer}         get the carrier's credential form
- 3. POST /policy_holder_sdk/policy_holder  submit credentials, get a task
- 4. GET  /v3/sdk/progress/{task}/stream    watch progress (SSE — separate base URL, see below)
+ 3. POST /policy_holder  submit credentials, get a task
+ 4. GET  /v3/connect/progress/{task}/stream    watch progress (SSE — separate base URL, see below)
       └─ if multi-factor is required:
          PUT /validate-credentials/{ph}/{task}  {method}
          PUT /validate-credentials/{ph}/{task}  {code}
- 5. GET  /policy_holder_sdk/policy_holder/{ph}  confirm final state
+ 5. GET  /policy_holder/{ph}  confirm final state
 ```
 
 Steps 1–3 and 5 are relative to the base URL
 (`https://app.tpastream.com/connect/v1`). Step 4 is the one deliberate
 exception: the progress stream is served by a different backend at
-`https://app.tpastream.com/v3/sdk/...` and authenticates with the
+`https://app.tpastream.com/v3/connect/...` and authenticates with the
 per-task `task_token` instead of the usual headers — details in the
 [reference](/connect-api/reference#event-stream). A plain polling GET
 under the normal base URL works as an alternative.

--- a/docs/connect-api/quickstart.md
+++ b/docs/connect-api/quickstart.md
@@ -32,7 +32,7 @@ It creates or resolves the member, attaches them to the employer, and
 returns the carriers available to them.
 
 ```bash
-tpa -X POST "$TPA_BASE/tpastream_sdk" -d '{
+tpa -X POST "$TPA_BASE/bootstrap" -d '{
   "system_key": "EMP-1234",
   "vendor": "internal",
   "employer_name": "Acme Corp",
@@ -121,7 +121,7 @@ account on the member's behalf. They map to `accept` and
 ## 4. Submit credentials
 
 ```bash
-tpa -X POST "$TPA_BASE/policy_holder_sdk/policy_holder" -d '{
+tpa -X POST "$TPA_BASE/policy_holder" -d '{
   "user_email": "member@example.com",
   "employer_id": 203246,
   "payer_id": 6,
@@ -161,7 +161,7 @@ Three things to note:
 
 To **reconnect** an existing policy holder after a credential change,
 send the same body as a `PUT` to
-`/policy_holder_sdk/policy_holder/{policy_holder_id}`.
+`/policy_holder/{policy_holder_id}`.
 
 ## 5. Watch the validation
 
@@ -169,7 +169,7 @@ The credential submit returned a `task_id` and a `task_token`.
 Subscribe to the event stream and states arrive as they happen:
 
 ```bash
-curl -N "https://app.tpastream.com/v3/sdk/progress/3bb088ed-cc38-4e0f-919f-f2060014ac44/stream?token=$TASK_TOKEN"
+curl -N "https://app.tpastream.com/v3/connect/progress/3bb088ed-cc38-4e0f-919f-f2060014ac44/stream?token=$TASK_TOKEN"
 ```
 
 Each connection is capped at ~10 minutes; on the `timeout` event,
@@ -221,7 +221,7 @@ about a third of real connections hit it.
 ## 6. Confirm the connection
 
 ```bash
-tpa -G "$TPA_BASE/policy_holder_sdk/policy_holder/630364" \
+tpa -G "$TPA_BASE/policy_holder/630364" \
     --data-urlencode "employer_id=203246" \
     --data-urlencode "email=$TPA_MEMBER"
 ```

--- a/docs/connect-api/reference.md
+++ b/docs/connect-api/reference.md
@@ -9,7 +9,7 @@ Base URL: `https://app.tpastream.com/connect/v1`
 
 Every request needs the headers described in
 [Authentication](/connect-api/authentication#headers). Every request
-except `POST /tpastream_sdk` must also
+except `POST /bootstrap` must also
 [identify the member](/connect-api/authentication#identifying-the-member).
 
 All successful responses are wrapped in a `data` envelope:
@@ -22,12 +22,12 @@ All successful responses are wrapped in a `data` envelope:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `POST` | `/tpastream_sdk` | Bootstrap the member; list carriers |
+| `POST` | `/bootstrap` | Bootstrap the member; list carriers |
 | `GET` | `/payer/{employer_id}/{payer_id}` | Carrier detail and credential schema |
 | `GET` | `/terms_of_service` | Current terms of use HTML |
-| `POST` | `/policy_holder_sdk/policy_holder` | Submit credentials, start validation |
-| `PUT` | `/policy_holder_sdk/policy_holder/{id}` | Resubmit credentials for an existing connection |
-| `GET` | `/policy_holder_sdk/policy_holder/{id}` | Connection status |
+| `POST` | `/policy_holder` | Submit credentials, start validation |
+| `PUT` | `/policy_holder/{id}` | Resubmit credentials for an existing connection |
+| `GET` | `/policy_holder/{id}` | Connection status |
 | `GET` | `/validate-credentials/{ph_id}/{task_id}` | Validation state |
 | `PUT` | `/validate-credentials/{ph_id}/{task_id}` | Supply an MFA method or code |
 | `GET` | `/fix-credentials` | All of the member's connections |
@@ -35,7 +35,7 @@ All successful responses are wrapped in a `data` envelope:
 
 ---
 
-## POST /tpastream_sdk
+## POST /bootstrap
 
 Creates or resolves the member, attaches them to the employer, and
 returns the carriers available to them. The only endpoint that may
@@ -101,7 +101,7 @@ credential submit.
 
 ---
 
-## POST /policy_holder_sdk/policy_holder
+## POST /policy_holder
 
 Submits credentials, creates the connection, and dispatches a validation
 against the carrier.
@@ -134,7 +134,7 @@ failures return `422` with per-field detail.
 
 ---
 
-## PUT /policy_holder_sdk/policy_holder/\{policy_holder_id\}
+## PUT /policy_holder/\{policy_holder_id\}
 
 Identical body and response to the `POST`. Use when the member is fixing
 credentials on a connection that already exists rather than making a new
@@ -145,7 +145,7 @@ carrier returns `403`.
 
 ---
 
-## GET /policy_holder_sdk/policy_holder/\{policy_holder_id\}
+## GET /policy_holder/\{policy_holder_id\}
 
 **Query** — `email` (required), `employer_id` (required).
 
@@ -215,11 +215,11 @@ input rather than reporting the outcome.
 ## Event stream {#event-stream}
 
 ```
-GET https://app.tpastream.com/v3/sdk/progress/{task_id}/stream?token={task_token}
+GET https://app.tpastream.com/v3/connect/progress/{task_id}/stream?token={task_token}
 ```
 
 Server-sent events for one validation task. Note the base URL: this
-endpoint lives under `/v3/sdk`, not under the Connect API prefix, and
+endpoint lives under `/v3/connect`, not under the Connect API prefix, and
 authenticates with the `task_token` from the credential submit instead
 of the usual headers.
 
@@ -256,7 +256,7 @@ in on the carrier's website and is redirected back to your application.
 **This step requires a browser.** There is no server-to-server
 equivalent, because the member authenticates directly with the carrier.
 
-Both endpoints require the `X-SDK-State-Id` header — an opaque string you
+Both endpoints require the `X-Connect-State-Id` header — an opaque string you
 generate per member session and reuse across the flow.
 
 ### POST /interop

--- a/docs/connect-api/two-factor.md
+++ b/docs/connect-api/two-factor.md
@@ -145,14 +145,14 @@ The recommended way to watch a validation is the event stream — states
 arrive as they happen, with nothing to poll:
 
 ```
-GET https://app.tpastream.com/v3/sdk/progress/{task_id}/stream?token={task_token}
+GET https://app.tpastream.com/v3/connect/progress/{task_id}/stream?token={task_token}
 ```
 
 Authentication is the `task_token` returned alongside `task_id` on the
 credential submit — a short-lived JWT bound to that one task. From curl:
 
 ```bash
-curl -N "https://app.tpastream.com/v3/sdk/progress/$TASK_ID/stream?token=$TASK_TOKEN"
+curl -N "https://app.tpastream.com/v3/connect/progress/$TASK_ID/stream?token=$TASK_TOKEN"
 ```
 
 Three event types arrive:
@@ -175,7 +175,7 @@ Each stream connection is capped at about ten minutes, and each
 stays subscribable for its entire lifetime. When you receive `timeout`
 (or lose the connection):
 
-1. `GET /policy_holder_sdk/policy_holder/{id}` — while the validation
+1. `GET /policy_holder/{id}` — while the validation
    is alive, the response includes the active `task_id` and a **fresh
    `task_token`**.
 2. Resubscribe to the stream with the new token.


### PR DESCRIPTION
Companion to LakeEriePartners/stream#15078 — Steve caught the pages documenting SDK-era route names (`POST /tpastream_sdk`, `/policy_holder_sdk/policy_holder`, `X-SDK-State-Id`, `/v3/sdk/...`) under the prefix we renamed specifically to get "sdk" out of the public contract.

All five pages swept to the clean spellings the stream PR adds: `/bootstrap`, `/policy_holder[/{id}]`, `X-Connect-State-Id`, `/v3/connect/progress/...`. The legacy-path note in authentication.md now records that every SDK-era spelling remains a valid alias. The overview diagram's step-1 annotation reworded ("create or resolve the member") since "bootstrap the member" next to `POST /bootstrap` read as an echo.

No conflict with #37 (touches a different hunk of overview.md).

**Do not merge before stream#15078 is live in prod** — these pages document routes that 404 until it rolls. Build clean, no broken links or anchors from connect-api pages.
