### PR TITLE
Document claim types

### DIFF
--- a/docs/api/claim-types.md
+++ b/docs/api/claim-types.md
@@ -1,0 +1,112 @@
+---
+title: Claim Types
+sidebar_label: Claim Types
+---
+
+# Claim Types
+
+Every claim carries a `type` describing what kind of care it covers.
+It serializes as a nested object:
+
+```json
+{
+  "type": {
+    "name": "medical",
+    "type_id": 1
+  }
+}
+```
+
+The set is closed. There are five values, they are fixed in the
+application rather than stored in a configurable table, and they are
+not tenant-configurable — you will not see a different set for a
+different employer.
+
+| `name` | `type_id` | Suggested label |
+|---|---|---|
+| `medical` | 1 | Medical |
+| `dental` | 2 | Dental |
+| `rx` | 3 | Rx |
+| `vision` | 4 | Vision |
+| `facility` | 5 | Facility |
+
+A static five-entry map is enough to render these. You don't need to
+handle carrier-specific codes: carriers send us a wide range of
+proprietary type codes, and we normalize all of them onto these five
+before they reach the API.
+
+## `type` can be null
+
+When the carrier doesn't tell us what kind of claim it is, the whole
+`type` object is `null` — not an object with an empty `name`:
+
+```json
+{
+  "type": null
+}
+```
+
+This is uncommon but not rare, so handle it explicitly rather than
+assuming `type` is always present. Displaying it as "Unknown" is the
+convention we use in the TPA Stream web app. The
+[claim webhook example payload](/connect/webhook-examples#claim-webhook)
+shows a claim in this state.
+
+## `name` values are identifiers, not labels
+
+The `name` strings are stable machine identifiers. They are always
+lowercase, so you get `rx` — never `Rx` or `RX`.
+
+Don't render them to end users as-is. If you're generating labels
+programmatically, title-casing gets you four of the five and you'll
+want to special-case the fifth:
+
+```js
+const CLAIM_TYPE_LABELS = {
+  medical: 'Medical',
+  dental: 'Dental',
+  rx: 'Rx',
+  vision: 'Vision',
+  facility: 'Facility',
+};
+
+const claimTypeLabel = (type) =>
+  CLAIM_TYPE_LABELS[type?.name] ?? 'Unknown';
+```
+
+Match on `name` rather than `type_id` if you want your code to stay
+readable; the two are equivalent and always travel together.
+
+## What `facility` means
+
+Four of the five names are self-explanatory. `facility` is the one
+worth a note: it means facility-billed care — typically an inpatient
+hospital stay — as opposed to a professional claim billed by an
+individual provider.
+
+It's the rarest of the five by a wide margin. Whether you surface it
+as its own category, relabel it something like "Hospital", or fold it
+into Medical for member-facing copy is a presentation decision on your
+side. We'd just recommend not showing the bare word `facility` to a
+member without context.
+
+## Field naming
+
+The REST API emits `type_id` in snake_case, matching the rest of the
+API. If you're seeing `typeId`, something in your own stack is
+converting keys to camelCase — worth confirming before you key a
+lookup table off the field name.
+
+## Prescription type
+
+Claim *lines* carry a separate and unrelated `prescription_type_id` /
+`prescription_type_str` pair, which describes whether a prescription
+is generic or brand:
+
+| `prescription_type_str` | `prescription_type_id` |
+|---|---|
+| `generic` | 1 |
+| `brand` | 2 |
+
+Like claim type, it's nullable, and it appears on the claim line
+rather than the claim.

--- a/docs/connect/webhooks-claim.md
+++ b/docs/connect/webhooks-claim.md
@@ -39,7 +39,8 @@ your endpoint.
 
 POST with `Content-Type: application/json`. See
 [Webhook Examples](/connect/webhook-examples) for the full payload
-shape.
+shape, and [Claim Types](/api/claim-types) for the values the `type`
+field can take.
 
 ## Retry behavior and 406
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -42,6 +42,7 @@ const sidebars: SidebarsConfig = {
         "api/ssh-keys",
         "api/gpg-keys",
         "api/date-ranges",
+        "api/claim-types",
       ],
     },
   ],


### PR DESCRIPTION
Adds a Claim Types page to the REST API guide.

## Why

Spence asked whether our expense types need a translation layer before they display them in their front end (Zoho Desk #10013). The answer is short — five values, closed set, static map is enough — but nothing in the docs said so, and the OpenAPI spec alone doesn't get you there:

```json
"ClaimType": {
  "properties": {
    "name":    { "enum": ["medical", "dental", "rx", "vision", "facility"] },
    "type_id": { "enum": [1, 2, 3, 4, 5] }
  }
}
```

Two independent enums, so there's no way to tell that `rx` is 3. The spec also doesn't mark the field nullable, and `type` genuinely does come back as `null` — about 0.3% of claims across the platform, and the [existing webhook example payload](https://github.com/LakeEriePartners/developer-docs/blob/master/docs/connect/webhook-examples.md) already shows a claim in that state.

## What's in the page

- The id ↔ name pairing as one table, with suggested display labels
- `type: null` and why you have to handle it
- `name` values are lowercase identifiers, not labels — `rx`, never `Rx`; sample label map
- What `facility` means (facility-billed care, typically inpatient) and a note not to show the bare word to a member
- A note that the API emits `type_id`, so `typeId` means something in the caller's stack is camelizing
- The unrelated-but-similarly-shaped `prescription_type_*` pair on claim lines, since that's the field people reach for next

Also cross-linked from the claim webhook page.

## Verification

`npm run build` succeeds, `/api/claim-types` renders, the sidebar entry lands under REST API, and the `#claim-webhook` anchor on the cross-link resolves.

While working on this I hit an intermittent SSG failure — `Can't render static file` with `TypeError: Cannot read properties of undefined (reading 'id')` in the openapi theme's `ApiItem`, affecting a leading block of the generated `api-reference/*` pages (count varied between 34 and 90 across runs). It is unrelated to this change: it reproduced on a clean tree with these changes stashed, and it is not caused by the OpenAPI spec content. `npx docusaurus clear` resolved it and it has not recurred across many subsequent builds, cold or warm. Master builds clean. Details in the thread below.

## Follow-up worth considering

The cleanest long-term fix is enriching `ClaimTypeSchema` in stream so the spec itself carries per-value descriptions and marks `type` nullable — then this page shrinks to just the display guidance. Didn't want to bundle a stream change into a docs PR.



Companion stream PR (adds the descriptions + nullable marker to the spec itself): https://github.com/LakeEriePartners/stream/pull/15103

