### PR TITLE
Document the login problem webhook + the events feed

### DIFF
--- a/docs/connect/events-feed.md
+++ b/docs/connect/events-feed.md
@@ -1,0 +1,121 @@
+---
+title: Events Feed
+sidebar_label: Events Feed
+---
+
+# Events Feed
+
+The events feed is the **durable companion to the webhooks**. Every
+occurrence that fires (or would fire) a
+[Claim Webhook](/connect/webhooks-claim),
+[First Crawl Completion Webhook](/connect/webhooks-crawl), or
+[Login Problem Webhook](/connect/webhooks-login-problem) is also
+recorded as an immutable event you can read back with a simple
+cursor-paged GET.
+
+Webhooks are push: if your endpoint is down for longer than the
+[retry window](/connect/webhook-security#response-codes-and-retries),
+the notification is gone and you have no way to know. The feed fixes
+that failure mode:
+
+- **Nothing can be missed.** Page forward with a cursor; an event is
+  never inserted behind a cursor you've already passed.
+- **Self-serve reconciliation.** Periodically sweep the feed to verify
+  your webhook consumer didn't drop anything.
+- **Recovery after downtime.** Come back up, resume from your last
+  cursor, and process everything that happened while you were down.
+
+You can use the feed **instead of** webhooks (poll it on a schedule)
+or **alongside** them (webhooks as the low-latency signal, the feed as
+the source of truth). New events become visible in the feed shortly
+after they occur — typically within a minute or two.
+
+## Endpoint
+
+```
+GET https://app.tpastream.com/api/v2/events
+```
+
+Authentication is the same as the rest of the
+[REST API](/api/authentication) — SSH-JWT (preferred) or your legacy
+API key. Results are scoped to your tenant.
+
+### Query parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `after` | `0` | Cursor: return only events with `id` greater than this. Pass the highest `id` you've processed. |
+| `types` | all | Comma-separated filter: `new_claim`, `crawl_completion`, `login_problem`. |
+| `limit` | `100` | Page size, 1–1000. |
+
+### Response
+
+```json
+{
+  "data": [
+    {
+      "id": 18234,
+      "type": "new_claim",
+      "created": "2026-07-30T14:03:11.482910+00:00",
+      "data": {
+        "claim_medical_id": 4821223,
+        "policy_holder_id": 189162
+      }
+    },
+    {
+      "id": 18235,
+      "type": "login_problem",
+      "created": "2026-07-30T14:04:02.118834+00:00",
+      "data": {
+        "policy_holder_id": 189162,
+        "payer_id": 42,
+        "login_problem": "invalid"
+      }
+    }
+  ],
+  "has_more": false
+}
+```
+
+`has_more: true` means another page is immediately available — keep
+paging with `after=<last id>` until it comes back `false`.
+
+## Event types
+
+| `type` | Fires when | `data` fields |
+|---|---|---|
+| `new_claim` | A claim is retrieved or updated for one of your members (same trigger as the [Claim Webhook](/connect/webhooks-claim)). | `claim_medical_id`, `policy_holder_id` |
+| `crawl_completion` | A first crawl completion is posted for a policy holder (same trigger as the [First Crawl Completion Webhook](/connect/webhooks-crawl); recorded for tenants with that webhook configured). | `crawl_id`, `policy_holder_id`, `success`, `crawl_claim_ids` |
+| `login_problem` | A policy holder's login state changes (same trigger as the [Login Problem Webhook](/connect/webhooks-login-problem)). | `policy_holder_id`, `payer_id`, `login_problem` |
+
+Events are deliberately **thin**: they carry identifiers and the state
+change, not full resources. Fetch the full record through the REST API
+when you need it (for example `claim_medical_id` → the claims API).
+Unlike webhooks, `new_claim` and `login_problem` events are recorded
+whether or not you have the corresponding webhook URL configured.
+
+## Consuming the feed
+
+The canonical consumer is a small poll loop:
+
+1. Persist a single integer: the highest event `id` you've processed.
+2. On a schedule (every minute is plenty), `GET /api/v2/events?after=<cursor>`.
+3. Process each event idempotently, then advance the cursor.
+4. If `has_more` is true, request the next page immediately.
+
+Guarantees to build against:
+
+- `id` is **strictly increasing** and never back-fills: once you've
+  seen id N, no event with id ≤ N will ever appear later.
+- Delivery is **at-least-once from your perspective** (you choose when
+  to advance the cursor), so make processing idempotent.
+- Events are retained for **90 days**. Don't let a consumer lag longer
+  than that; for cold-start backfills beyond the window, use the REST
+  API instead.
+
+## Relationship to webhook replays
+
+Manually replayed webhooks (for example the
+[crawl completion replay](/connect/webhooks-crawl#replaying-a-crawl-completion-post))
+re-send the webhook only — they do **not** create new feed events,
+since the original occurrence is already recorded.

--- a/docs/connect/events-feed.md
+++ b/docs/connect/events-feed.md
@@ -18,12 +18,14 @@ Webhooks are push: if your endpoint is down for longer than the
 the notification is gone and you have no way to know. The feed fixes
 that failure mode:
 
-- **Nothing can be missed.** Page forward with a cursor; an event is
-  never inserted behind a cursor you've already passed.
+- **Nothing can be missed** (within the 90-day retention window).
+  Page forward with a cursor; an event is never inserted behind a
+  cursor you've already passed.
 - **Self-serve reconciliation.** Periodically sweep the feed to verify
   your webhook consumer didn't drop anything.
 - **Recovery after downtime.** Come back up, resume from your last
-  cursor, and process everything that happened while you were down.
+  cursor, and process everything that happened while you were down —
+  complete as long as your cursor is newer than the retention window.
 
 You can use the feed **instead of** webhooks (poll it on a schedule)
 or **alongside** them (webhooks as the low-latency signal, the feed as
@@ -32,7 +34,7 @@ after they occur — typically within a minute or two.
 
 ## Endpoint
 
-```
+```text
 GET https://app.tpastream.com/api/v2/events
 ```
 
@@ -110,8 +112,10 @@ Guarantees to build against:
 - Delivery is **at-least-once from your perspective** (you choose when
   to advance the cursor), so make processing idempotent.
 - Events are retained for **90 days**. Don't let a consumer lag longer
-  than that; for cold-start backfills beyond the window, use the REST
-  API instead.
+  than that. If your cursor is older than the retention window (or you
+  are backfilling from before the feed existed), treat it as a cold
+  start: reconcile current state through the REST API, then resume the
+  feed from the oldest retained event (`after=0`).
 
 ## Relationship to webhook replays
 

--- a/docs/connect/overview.md
+++ b/docs/connect/overview.md
@@ -36,7 +36,17 @@ application via:
   claim.
 - [First Crawl Completion Webhook](/connect/webhooks-crawl) — fires
   once after the first successful crawl per policy holder.
+- [Login Problem Webhook](/connect/webhooks-login-problem) — fires
+  when a connected carrier login stops working (or starts working
+  again).
 
-Both webhook payloads are signed; see
-[Webhook Security](/connect/webhook-security) before you wire either
-up in production.
+All webhook payloads are signed; see
+[Webhook Security](/connect/webhook-security) before you wire any of
+them up in production.
+
+## Companion: events feed
+
+Webhooks are push-only. The [Events Feed](/connect/events-feed) is
+the durable, cursor-paged record of the same occurrences — use it to
+recover from missed webhooks, reconcile your consumer, or skip
+webhooks entirely and poll.

--- a/docs/connect/webhook-examples.md
+++ b/docs/connect/webhook-examples.md
@@ -5,7 +5,7 @@ sidebar_label: Webhook Examples
 
 # Webhook Payload Examples
 
-Both example payloads below show the request body TPA Stream sends as
+The example payloads below show the request body TPA Stream sends as
 the POST body, with `Content-Type: application/json`.
 
 ## Claim webhook
@@ -138,6 +138,7 @@ the POST body, with `Content-Type: application/json`.
 ```json
 {
   "data": {
+    "crawl_claim_ids": [],
     "members": [
       {
         "id": 63167
@@ -149,6 +150,36 @@ the POST body, with `Content-Type: application/json`.
       "login_problem": "invalid"
     },
     "success": false
+  }
+}
+```
+
+On a successful crawl, `crawl_claim_ids` carries the ids of the claims
+retrieved by that crawl (empty on failures and on
+[manual replays](/connect/webhooks-crawl#replaying-a-crawl-completion-post)).
+
+## Login problem webhook
+
+```json
+{
+  "data": {
+    "members": [
+      {
+        "id": 63167,
+        "employer": {
+          "id": 999
+        }
+      }
+    ],
+    "policy_holder": {
+      "id": 189162,
+      "payer": {
+        "id": 42,
+        "name": "Anthem"
+      },
+      "login_correction_message": "The login information you provided for Anthem is invalid. Please re-enter your login information.",
+      "login_problem": "invalid"
+    }
   }
 }
 ```

--- a/docs/connect/webhook-examples.md
+++ b/docs/connect/webhook-examples.md
@@ -155,8 +155,9 @@ the POST body, with `Content-Type: application/json`.
 ```
 
 On a successful crawl, `crawl_claim_ids` carries the ids of the claims
-retrieved by that crawl (empty on failures and on
-[manual replays](/connect/webhooks-crawl#replaying-a-crawl-completion-post)).
+retrieved by that crawl; on failed crawls it is an empty array. On
+[manual replays](/connect/webhooks-crawl#replaying-a-crawl-completion-post)
+the field is omitted from the payload entirely.
 
 ## Login problem webhook
 

--- a/docs/connect/webhooks-login-problem.md
+++ b/docs/connect/webhooks-login-problem.md
@@ -1,0 +1,61 @@
+---
+title: Login Problem Webhook
+sidebar_label: Login Problem Webhook
+---
+
+# Login Problem Webhook
+
+TPA Stream can POST to a customer-provided URL whenever the **login
+state of a carrier login (policy holder) changes** — for example when
+a previously working credential becomes invalid, gets locked by the
+carrier, or starts requiring multi-factor authentication.
+
+This is the webhook to wire up if your application prompts members to
+fix their credentials: it tells you the moment a login stops working,
+without waiting for the member to notice.
+
+## Trigger
+
+The webhook fires whenever TPA Stream's crawler detects that a policy
+holder's `login_problem` state has **changed** — including a change
+back to `valid` after the member fixes their credentials. One POST is
+made per tenant associated with the policy holder.
+
+Common `login_problem` values:
+
+| Value | Meaning |
+|---|---|
+| `valid` | Credentials work. |
+| `invalid` | Carrier rejected the username/password. |
+| `locked` | The carrier locked the account (usually too many bad attempts). |
+| `needs_two_factor` | The carrier requires multi-factor authentication to proceed. |
+| `inactive` | The account appears inactive on the carrier side. |
+| `sec_question` | A security question is blocking the login. |
+
+The set of values may grow over time; treat unknown values as "member
+action may be required" and surface `login_correction_message`, which
+always carries a member-readable explanation.
+
+## Configuring the URL
+
+To edit the URL, open **Account Settings** on the settings page, just
+like the [Claim Webhook URL](/connect/webhooks-claim#configuring-the-url).
+This webhook is feature-flagged per tenant — contact TPA Stream
+support to enable it if the field isn't shown.
+
+## Request shape
+
+POST with `Content-Type: application/json`. See
+[Webhook Examples](/connect/webhook-examples#login-problem-webhook)
+for the full payload shape.
+
+Like every TPA Stream webhook, the request is signed via the
+`TPAStream-Signature` header and retried on failure per
+[Webhook Security](/connect/webhook-security#response-codes-and-retries).
+
+## Missed a webhook?
+
+Webhook delivery is at-most-4-hours of retries. If your endpoint was
+down longer than that — or you want to reconcile — use the
+[Events Feed](/connect/events-feed), which durably records every
+login problem change and lets you page forward from a cursor.

--- a/docs/connect/webhooks-login-problem.md
+++ b/docs/connect/webhooks-login-problem.md
@@ -57,5 +57,5 @@ Like every TPA Stream webhook, the request is signed via the
 
 Webhook delivery is at-most-4-hours of retries. If your endpoint was
 down longer than that — or you want to reconcile — use the
-[Events Feed](/connect/events-feed), which durably records every
-login problem change and lets you page forward from a cursor.
+[Events Feed](/connect/events-feed), which records every login
+problem change for 90 days and lets you page forward from a cursor.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -13,8 +13,10 @@ const sidebars: SidebarsConfig = {
         "connect/quickstart",
         "connect/webhooks-claim",
         "connect/webhooks-crawl",
+        "connect/webhooks-login-problem",
         "connect/webhook-security",
         "connect/webhook-examples",
+        "connect/events-feed",
       ],
     },
     {


### PR DESCRIPTION
Two additions to the Connect docs:

**Login Problem Webhook** — the third companion webhook was undocumented (its payload appeared only as an unlabeled blob in the examples page). New page covers the trigger, common `login_problem` values, per-tenant config/feature flag, and signature/retry cross-links, plus a labeled payload example.

**Events Feed** — documents `GET /api/v2/events` from https://github.com/LakeEriePartners/stream/pull/15106: the durable cursor-paged record behind all three webhooks. Endpoint, params, event types, the canonical consumer loop, guarantees (strictly-increasing cursor, at-least-once, 90-day retention), and replay semantics.

Also: overview's companion section now lists all three webhooks + the feed, sidebar entries added, and the crawl webhook example gains the `crawl_claim_ids` field it actually carries.

**Hold merge until the stream PR above is deployed** — the feed page documents an endpoint that doesn't exist in prod yet. Docusaurus build is clean (the two broken-anchor warnings are pre-existing, in generated api-reference and sdk/faq).