### PR TITLE
Fix the stale /docs prefix on the SDK Quickstart link

### DIFF
--- a/docs/connect/origin-policy.md
+++ b/docs/connect/origin-policy.md
@@ -88,7 +88,7 @@ For **local development**:
 
 ## Related
 
-* [SDK Quickstart](/docs/connect/quickstart) — the smallest possible
+* [SDK Quickstart](/connect/quickstart) — the smallest possible
   page that mounts the SDK.
 * [Stream Connect SDK changelog][changelog] — `0.8.2` is the first
   release that includes the init-time guard.


### PR DESCRIPTION
One-line fix for a broken link the docs build reports.

`docs/connect/origin-policy.md` linked to `/docs/connect/quickstart`, but `routeBasePath` is `"/"` (docusaurus.config.ts:41), so pages are served without a `/docs` prefix — the link 404'd. Every other internal link under `docs/connect/` already uses the bare form (`/connect/quickstart`, `/connect/webhook-examples`, `/api/authentication`, …).

## Verification

`npm run build` before: one broken link reported.

```
- Broken link on source page path = /connect/origin-policy:
   -> linking to /docs/connect/quickstart
```

After: the broken-links section is gone entirely.

## Related

The build also reported a broken anchor, `#tag/email-delivery-events` on the generated `/api-reference/get-v-2-mailgun-webhook` page. That one originates in the OpenAPI spec rather than this repo, so it's fixed in stream: https://github.com/LakeEriePartners/stream/pull/15161 — I confirmed both together by building this branch against the patched spec, which leaves the broken-anchor report clean apart from the unrelated SDK item below.

Still outstanding and **not** fixed here: `/sdk/faq` links to `/sdk/client-usage#callbacks`, an anchor that doesn't exist. Those pages are cloned at build time from `stream-connect-js-sdk` by `scripts/clone-sdk-docs.sh`, so the fix belongs in that repo.

